### PR TITLE
feat: added support for Google Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,23 @@ npm install && npm run build
 - `gmail_threads_list` — Search threads
 - `gmail_threads_get` — Read a full thread
 
-**Total: 24 tools** (vs 200-400 in the old implementation)
+### `tasks` (14 tools)
+- `tasks_tasklists_list` — List task lists
+- `tasks_tasklists_get` — Get a task list
+- `tasks_tasklists_insert` — Create a task list
+- `tasks_tasklists_update` — Replace a task list (full update)
+- `tasks_tasklists_patch` — Update a task list (partial)
+- `tasks_tasklists_delete` — Delete a task list
+- `tasks_tasks_list` — List tasks (filters: completed/hidden/due dates)
+- `tasks_tasks_get` — Get a task
+- `tasks_tasks_insert` — Create a task (optionally nested or positioned)
+- `tasks_tasks_update` — Replace a task (full update)
+- `tasks_tasks_patch` — Update a task (common use: mark complete)
+- `tasks_tasks_move` — Move a task within/across lists or reorder
+- `tasks_tasks_delete` — Delete a task
+- `tasks_tasks_clear` — Hide all completed tasks in a list
+
+**Total: 38 tools** (vs 200-400 in the old implementation)
 
 ## Adding new tools
 

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -62,10 +62,11 @@ describe("tool definitions integrity", () => {
     expect(SERVICE_TOOLS["calendar"].length).toBe(5);
     expect(SERVICE_TOOLS["docs"].length).toBe(3);
     expect(SERVICE_TOOLS["gmail"].length).toBe(5);
+    expect(SERVICE_TOOLS["tasks"].length).toBe(14);
   });
 
-  it("total tool count is 25", () => {
-    expect(allTools.length).toBe(25);
+  it("total tool count is 39", () => {
+    expect(allTools.length).toBe(39);
   });
 
   it("all params have required fields", () => {
@@ -76,6 +77,64 @@ describe("tool definitions integrity", () => {
         expect(p.description).toBeTruthy();
         expect(["string", "number", "boolean"]).toContain(p.type);
         expect(typeof p.required).toBe("boolean");
+      }
+    }
+  });
+});
+
+describe("tasks service shape", () => {
+  const tasksTools = SERVICE_TOOLS["tasks"];
+
+  it("all tools route to the 'tasks' gws service", () => {
+    for (const tool of tasksTools) {
+      expect(tool.command[0]).toBe("tasks");
+    }
+  });
+
+  it("exposes both tasklists and tasks resources", () => {
+    const resources = new Set(tasksTools.map((t) => t.command[1]));
+    expect(resources.has("tasklists")).toBe(true);
+    expect(resources.has("tasks")).toBe(true);
+  });
+
+  it("requires 'tasklist' on every tasklists method except list and insert", () => {
+    const tasklists = tasksTools.filter((t) => t.command[1] === "tasklists");
+    for (const tool of tasklists) {
+      const method = tool.command[2];
+      if (method === "list" || method === "insert") continue;
+      const tasklistParam = tool.params.find((p) => p.name === "tasklist");
+      expect(tasklistParam?.required, `${tool.name} should require 'tasklist'`).toBe(true);
+    }
+  });
+
+  it("requires 'tasklist' on every tasks method", () => {
+    const taskOps = tasksTools.filter((t) => t.command[1] === "tasks");
+    for (const tool of taskOps) {
+      const tasklistParam = tool.params.find((p) => p.name === "tasklist");
+      expect(tasklistParam?.required, `${tool.name} should require 'tasklist'`).toBe(true);
+    }
+  });
+
+  it("requires 'task' on per-task operations (get, update, patch, move, delete)", () => {
+    const PER_TASK_METHODS = new Set(["get", "update", "patch", "move", "delete"]);
+    const perTask = tasksTools.filter(
+      (t) => t.command[1] === "tasks" && PER_TASK_METHODS.has(t.command[2]),
+    );
+    for (const tool of perTask) {
+      const taskParam = tool.params.find((p) => p.name === "task");
+      expect(taskParam?.required, `${tool.name} should require 'task'`).toBe(true);
+    }
+  });
+
+  it("declares bodyParams on insert/update/patch and only those", () => {
+    const NEEDS_BODY = new Set(["insert", "update", "patch"]);
+    for (const tool of tasksTools) {
+      const method = tool.command[2];
+      const hasBody = Array.isArray(tool.bodyParams) && tool.bodyParams.length > 0;
+      if (NEEDS_BODY.has(method)) {
+        expect(hasBody, `${tool.name} should declare bodyParams`).toBe(true);
+      } else {
+        expect(hasBody, `${tool.name} should not declare bodyParams`).toBe(false);
       }
     }
   });

--- a/src/services.ts
+++ b/src/services.ts
@@ -349,6 +349,170 @@ const gmailTools: ToolDef[] = [
   },
 ];
 
+// ── Tasks ───────────────────────────────────────────────────────────────
+
+const tasksTools: ToolDef[] = [
+  {
+    name: "tasks_tasklists_list",
+    description: "List the authenticated user's task lists.",
+    command: ["tasks", "tasklists", "list"],
+    params: [
+      { name: "maxResults", description: "Max task lists per page (1-100, default 20)", type: "number", required: false },
+      { name: "pageToken", description: "Token for the next page of results", type: "string", required: false },
+    ],
+  },
+  {
+    name: "tasks_tasklists_get",
+    description: "Get a task list by ID.",
+    command: ["tasks", "tasklists", "get"],
+    params: [
+      { name: "tasklist", description: "Task list ID (use \"@default\" for the user's default list)", type: "string", required: true },
+    ],
+  },
+  {
+    name: "tasks_tasklists_insert",
+    description: "Create a new task list.",
+    command: ["tasks", "tasklists", "insert"],
+    params: [],
+    bodyParams: [
+      { name: "title", description: "Task list title", type: "string", required: true },
+    ],
+  },
+  {
+    name: "tasks_tasklists_update",
+    description: "Replace a task list (full update). Use tasks_tasklists_patch for partial updates.",
+    command: ["tasks", "tasklists", "update"],
+    params: [
+      { name: "tasklist", description: "Task list ID to update", type: "string", required: true },
+    ],
+    bodyParams: [
+      { name: "title", description: "New task list title", type: "string", required: true },
+    ],
+  },
+  {
+    name: "tasks_tasklists_patch",
+    description: "Update a task list with patch semantics (only supplied fields change).",
+    command: ["tasks", "tasklists", "patch"],
+    params: [
+      { name: "tasklist", description: "Task list ID to update", type: "string", required: true },
+    ],
+    bodyParams: [
+      { name: "title", description: "New task list title", type: "string", required: false },
+    ],
+  },
+  {
+    name: "tasks_tasklists_delete",
+    description: "Delete a task list. If it contains assigned tasks, the originals (in Docs/Chat Spaces) are also removed.",
+    command: ["tasks", "tasklists", "delete"],
+    params: [
+      { name: "tasklist", description: "Task list ID to delete", type: "string", required: true },
+    ],
+  },
+  {
+    name: "tasks_tasks_list",
+    description: "List tasks in a task list. Excludes hidden and assigned tasks by default; set showHidden/showAssigned to include them.",
+    command: ["tasks", "tasks", "list"],
+    params: [
+      { name: "tasklist", description: "Task list ID (use \"@default\" for the default list)", type: "string", required: true },
+      { name: "maxResults", description: "Max tasks per page (1-100, default 20)", type: "number", required: false },
+      { name: "pageToken", description: "Token for the next page of results", type: "string", required: false },
+      { name: "showCompleted", description: "Include completed tasks (default true; ignored unless showHidden is also true)", type: "boolean", required: false },
+      { name: "showHidden", description: "Include hidden (cleared) tasks", type: "boolean", required: false },
+      { name: "showDeleted", description: "Include deleted tasks", type: "boolean", required: false },
+      { name: "showAssigned", description: "Include tasks assigned from Docs/Chat Spaces", type: "boolean", required: false },
+      { name: "completedMin", description: "Lower bound on completion date (RFC 3339)", type: "string", required: false },
+      { name: "completedMax", description: "Upper bound on completion date (RFC 3339)", type: "string", required: false },
+      { name: "dueMin", description: "Lower bound on due date (RFC 3339)", type: "string", required: false },
+      { name: "dueMax", description: "Upper bound on due date (RFC 3339)", type: "string", required: false },
+      { name: "updatedMin", description: "Lower bound on last-modified time (RFC 3339)", type: "string", required: false },
+    ],
+  },
+  {
+    name: "tasks_tasks_get",
+    description: "Get a task by ID.",
+    command: ["tasks", "tasks", "get"],
+    params: [
+      { name: "tasklist", description: "Task list ID", type: "string", required: true },
+      { name: "task", description: "Task ID", type: "string", required: true },
+    ],
+  },
+  {
+    name: "tasks_tasks_insert",
+    description: "Create a new task. Use parent to nest as a subtask, previous to position after a sibling.",
+    command: ["tasks", "tasks", "insert"],
+    params: [
+      { name: "tasklist", description: "Task list ID to insert into", type: "string", required: true },
+      { name: "parent", description: "Parent task ID (insert as a subtask under this task)", type: "string", required: false },
+      { name: "previous", description: "Sibling task ID (insert immediately after this task)", type: "string", required: false },
+    ],
+    bodyParams: [
+      { name: "title", description: "Task title", type: "string", required: true },
+      { name: "notes", description: "Free-text notes / body", type: "string", required: false },
+      { name: "status", description: "Task status: needsAction or completed", type: "string", required: false },
+      { name: "due", description: "Due date (RFC 3339, e.g. \"2026-06-01T00:00:00.000Z\")", type: "string", required: false },
+    ],
+  },
+  {
+    name: "tasks_tasks_update",
+    description: "Replace a task (full update). Use tasks_tasks_patch for partial updates.",
+    command: ["tasks", "tasks", "update"],
+    params: [
+      { name: "tasklist", description: "Task list ID", type: "string", required: true },
+      { name: "task", description: "Task ID to update", type: "string", required: true },
+    ],
+    bodyParams: [
+      { name: "title", description: "Task title", type: "string", required: true },
+      { name: "notes", description: "Free-text notes / body", type: "string", required: false },
+      { name: "status", description: "Task status: needsAction or completed", type: "string", required: false },
+      { name: "due", description: "Due date (RFC 3339)", type: "string", required: false },
+    ],
+  },
+  {
+    name: "tasks_tasks_patch",
+    description: "Update a task with patch semantics. Common use: complete a task by setting status to \"completed\".",
+    command: ["tasks", "tasks", "patch"],
+    params: [
+      { name: "tasklist", description: "Task list ID", type: "string", required: true },
+      { name: "task", description: "Task ID to update", type: "string", required: true },
+    ],
+    bodyParams: [
+      { name: "title", description: "Task title", type: "string", required: false },
+      { name: "notes", description: "Free-text notes / body", type: "string", required: false },
+      { name: "status", description: "Task status: needsAction or completed", type: "string", required: false },
+      { name: "due", description: "Due date (RFC 3339)", type: "string", required: false },
+    ],
+  },
+  {
+    name: "tasks_tasks_move",
+    description: "Move a task within its list or to another list. Use parent/previous to set position; destinationTasklist to change list.",
+    command: ["tasks", "tasks", "move"],
+    params: [
+      { name: "tasklist", description: "Source task list ID", type: "string", required: true },
+      { name: "task", description: "Task ID to move", type: "string", required: true },
+      { name: "parent", description: "New parent task ID (move as subtask under this task)", type: "string", required: false },
+      { name: "previous", description: "New sibling task ID (move immediately after this task)", type: "string", required: false },
+      { name: "destinationTasklist", description: "Destination task list ID (omit to move within the source list)", type: "string", required: false },
+    ],
+  },
+  {
+    name: "tasks_tasks_delete",
+    description: "Delete a task. If assigned from Docs/Chat Spaces, the original is also removed.",
+    command: ["tasks", "tasks", "delete"],
+    params: [
+      { name: "tasklist", description: "Task list ID", type: "string", required: true },
+      { name: "task", description: "Task ID to delete", type: "string", required: true },
+    ],
+  },
+  {
+    name: "tasks_tasks_clear",
+    description: "Hide all completed tasks in a list. Cleared tasks are not deleted but stop appearing in default list responses.",
+    command: ["tasks", "tasks", "clear"],
+    params: [
+      { name: "tasklist", description: "Task list ID to clear", type: "string", required: true },
+    ],
+  },
+];
+
 // ── Service registry ───────────────────────────────────────────────────
 
 export const SERVICE_TOOLS: Record<string, ToolDef[]> = {
@@ -357,6 +521,7 @@ export const SERVICE_TOOLS: Record<string, ToolDef[]> = {
   calendar: calendarTools,
   docs: docsTools,
   gmail: gmailTools,
+  tasks: tasksTools,
 };
 
 export const ALL_SERVICES = Object.keys(SERVICE_TOOLS);


### PR DESCRIPTION
# feat: add tasks service (Google Tasks API)

## Summary

Adds Google Tasks as a new service, exposing the full `tasks` surface of the `gws` CLI through 14 new MCP tools.

## New tools (14)

**Tasklists resource (6)**
- `tasks_tasklists_list` - list the user's task lists
- `tasks_tasklists_get` - get a task list
- `tasks_tasklists_insert` - create a task list
- `tasks_tasklists_update` - replace a task list (PUT)
- `tasks_tasklists_patch` - update a task list (PATCH, partial)
- `tasks_tasklists_delete` - delete a task list

**Tasks resource (8)**
- `tasks_tasks_list` - list tasks (filters: `showCompleted`, `showHidden`, `showDeleted`, `showAssigned`, `completedMin/Max`, `dueMin/Max`, `updatedMin`, pagination)
- `tasks_tasks_get` - get a task
- `tasks_tasks_insert` - create a task (with optional `parent`/`previous` to nest or position)
- `tasks_tasks_update` - replace a task (PUT)
- `tasks_tasks_patch` - update a task (PATCH; common use: set `status: "completed"`)
- `tasks_tasks_move` - move within or across lists, optionally re-parenting
- `tasks_tasks_delete` - delete a task
- `tasks_tasks_clear` - hide all completed tasks in a list

The `tasks` service is registered in `SERVICE_TOOLS` and exposed via `--services tasks` like any other service. No new CLI flags or new dependencies.

Both `update` (PUT) and `patch` (PATCH) are exposed for each resource because gws's CLI exposes both. 