### PR TITLE
chore: Node 24-ready action bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         node-version: [20, 22]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm


### PR DESCRIPTION
GitHub is force-migrating Node 20 JavaScript actions to Node 24 on **June 16, 2026** (deprecation warnings already showing in CI logs). This bumps the workflow action pins in this repo to their current Node 24-ready major versions.

## Bumps
- `actions/checkout@v4` -> `actions/checkout@v6`
- `actions/setup-node@v4` -> `actions/setup-node@v6`

Each target major was verified Node 24-ready via `runs.using: node24` in the action's `action.yml` at its latest release tag. Version pins only — no other workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
