### PR TITLE
fix(tasks): consolidate update and patch verbs to use patch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gws-mcp-server
 
-Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, and Tasks as a curated set of 41 [Model Context Protocol](https://modelcontextprotocol.io/) tools, built on the official [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli).
+Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, and Tasks as a curated set of 39 [Model Context Protocol](https://modelcontextprotocol.io/) tools, built on the official [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli).
 
 [![npm version](https://img.shields.io/npm/v/gws-mcp-server?style=flat-square)](https://www.npmjs.com/package/gws-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
@@ -118,23 +118,21 @@ npm install && npm run build
 - `gmail_threads_modify` — Add/remove labels on a thread (archive, mark read, star)
 - `gmail_drafts_create` — Create a draft (plain text and/or HTML, with reply threading via `threadId`). Drafts are never auto-sent
 
-### `tasks` (14 tools)
+### `tasks` (12 tools)
 - `tasks_tasklists_list` — List task lists
 - `tasks_tasklists_get` — Get a task list
 - `tasks_tasklists_insert` — Create a task list
-- `tasks_tasklists_update` — Replace a task list (full update)
-- `tasks_tasklists_patch` — Update a task list (partial)
+- `tasks_tasklists_update` — Update a task list (only supplied fields change)
 - `tasks_tasklists_delete` — Delete a task list
 - `tasks_tasks_list` — List tasks (filters: completed/hidden/due dates)
 - `tasks_tasks_get` — Get a task
 - `tasks_tasks_insert` — Create a task (optionally nested or positioned)
-- `tasks_tasks_update` — Replace a task (full update)
-- `tasks_tasks_patch` — Update a task (common use: mark complete)
+- `tasks_tasks_update` — Update a task (only supplied fields change; common use: mark complete)
 - `tasks_tasks_move` — Move a task within/across lists or reorder
 - `tasks_tasks_delete` — Delete a task
 - `tasks_tasks_clear` — Hide all completed tasks in a list
 
-**Total: 41 tools** (vs 200-400 in the old implementation)
+**Total: 39 tools** (vs 200-400 in the old implementation)
 
 ## Adding new tools
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gws-mcp-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gws-mcp-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.conorbronsdon/gws-mcp-server",
   "title": "Google Workspace MCP Server",
-  "description": "Google Workspace as 41 curated MCP tools: Gmail, Calendar, Drive, Sheets, Docs, and Tasks.",
+  "description": "Google Workspace as 39 curated MCP tools: Gmail, Calendar, Drive, Sheets, Docs, and Tasks.",
   "repository": {
     "url": "https://github.com/conorbronsdon/gws-mcp-server",
     "source": "github"

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getToolsForServices, SERVICE_TOOLS, ALL_SERVICES, buildAnnotations, type ToolDef } from "../services.js";
+import { buildArgs } from "../executor.js";
 
 describe("getToolsForServices", () => {
   it("returns tools for requested services", () => {
@@ -62,11 +63,11 @@ describe("tool definitions integrity", () => {
     expect(SERVICE_TOOLS["calendar"].length).toBe(5);
     expect(SERVICE_TOOLS["docs"].length).toBe(3);
     expect(SERVICE_TOOLS["gmail"].length).toBe(5);
-    expect(SERVICE_TOOLS["tasks"].length).toBe(14);
+    expect(SERVICE_TOOLS["tasks"].length).toBe(12);
   });
 
-  it("total tool count is 39", () => {
-    expect(allTools.length).toBe(39);
+  it("total tool count is 37", () => {
+    expect(allTools.length).toBe(37);
   });
 
   it("all params have required fields", () => {
@@ -137,6 +138,54 @@ describe("tasks service shape", () => {
         expect(hasBody, `${tool.name} should not declare bodyParams`).toBe(false);
       }
     }
+  });
+});
+
+// ── Tasks update tools use patch semantics ───────────────────────────────
+// The Tasks API's PUT methods require the resource's own `id` inside the
+// request body, which these schemas cannot supply — every call through the
+// old `update` verb failed with "Missing task ID" / "Missing task list ID".
+// The tools therefore route to the `patch` verb, where only supplied fields
+// change and partial bodies are valid.
+
+describe("tasks update tools (patch semantics)", () => {
+  const byName = new Map(SERVICE_TOOLS["tasks"].map((t) => [t.name, t]));
+  const tasksUpdate = byName.get("tasks_tasks_update")!;
+  const tasklistsUpdate = byName.get("tasks_tasklists_update")!;
+
+  it("tasks_tasks_update routes to the patch verb", () => {
+    expect(tasksUpdate.command).toEqual(["tasks", "tasks", "patch"]);
+  });
+
+  it("tasks_tasklists_update routes to the patch verb", () => {
+    expect(tasklistsUpdate.command).toEqual(["tasks", "tasklists", "patch"]);
+  });
+
+  it("all body fields are optional, so partial updates are schema-valid", () => {
+    for (const tool of [tasksUpdate, tasklistsUpdate]) {
+      for (const p of tool.bodyParams!) {
+        expect(p.required, `${tool.name}.${p.name} must be optional`).toBe(false);
+      }
+    }
+  });
+
+  it("a title-only call sends only title in the body (unsupplied fields untouched)", () => {
+    const args = buildArgs(tasksUpdate, {
+      tasklist: "@default",
+      task: "abc123",
+      title: "New title",
+    });
+    expect(args.slice(0, 3)).toEqual(["tasks", "tasks", "patch"]);
+    const jsonIdx = args.indexOf("--json");
+    expect(jsonIdx).toBeGreaterThan(-1);
+    // Body must contain exactly the supplied field — nothing injected that
+    // would overwrite notes/status/due on the server.
+    expect(JSON.parse(args[jsonIdx + 1])).toEqual({ title: "New title" });
+  });
+
+  it("no separate *_patch tools remain (one safe update verb per resource)", () => {
+    expect(byName.has("tasks_tasks_patch")).toBe(false);
+    expect(byName.has("tasks_tasklists_patch")).toBe(false);
   });
 });
 
@@ -237,8 +286,8 @@ describe("tool annotation classifications", () => {
       "sheets_values_update", "sheets_values_append",
       "calendar_events_insert", "calendar_events_update",
       "docs_create", "docs_batchUpdate",
-      "tasks_tasklists_insert", "tasks_tasklists_update", "tasks_tasklists_patch",
-      "tasks_tasks_insert", "tasks_tasks_update", "tasks_tasks_patch", "tasks_tasks_move",
+      "tasks_tasklists_insert", "tasks_tasklists_update",
+      "tasks_tasks_insert", "tasks_tasks_update", "tasks_tasks_move",
     ];
     for (const name of expectAdditive) {
       const tool = byName.get(name)!;
@@ -270,7 +319,7 @@ describe("tool annotation classifications", () => {
     }
   });
 
-  it("classification counts match the intended split (16 read / 5 destructive / 18 additive)", () => {
+  it("classification counts match the intended split (16 read / 5 destructive / 16 additive)", () => {
     const read = allTools.filter((t) => buildAnnotations(t).readOnlyHint === true).length;
     const destructive = allTools.filter((t) => buildAnnotations(t).destructiveHint === true).length;
     const additive = allTools.filter(
@@ -278,7 +327,7 @@ describe("tool annotation classifications", () => {
     ).length;
     expect(read).toBe(16);
     expect(destructive).toBe(5);
-    expect(additive).toBe(18);
+    expect(additive).toBe(16);
     expect(read + destructive + additive).toBe(allTools.length);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,7 @@ async function main() {
 
   const server = new McpServer({
     name: "gws-mcp-server",
-    version: "0.2.0",
+    version: "0.3.0",
   });
 
   // Register each tool, attaching MCP annotations derived from the ToolDef's

--- a/src/services.ts
+++ b/src/services.ts
@@ -440,18 +440,7 @@ const tasksTools: ToolDef[] = [
   },
   {
     name: "tasks_tasklists_update",
-    description: "Replace a task list (full update). Use tasks_tasklists_patch for partial updates.",
-    command: ["tasks", "tasklists", "update"],
-    params: [
-      { name: "tasklist", description: "Task list ID to update", type: "string", required: true },
-    ],
-    bodyParams: [
-      { name: "title", description: "New task list title", type: "string", required: true },
-    ],
-  },
-  {
-    name: "tasks_tasklists_patch",
-    description: "Update a task list with patch semantics (only supplied fields change).",
+    description: "Update a task list (only supplied fields change).",
     command: ["tasks", "tasklists", "patch"],
     params: [
       { name: "tasklist", description: "Task list ID to update", type: "string", required: true },
@@ -517,22 +506,7 @@ const tasksTools: ToolDef[] = [
   },
   {
     name: "tasks_tasks_update",
-    description: "Replace a task (full update). Use tasks_tasks_patch for partial updates.",
-    command: ["tasks", "tasks", "update"],
-    params: [
-      { name: "tasklist", description: "Task list ID", type: "string", required: true },
-      { name: "task", description: "Task ID to update", type: "string", required: true },
-    ],
-    bodyParams: [
-      { name: "title", description: "Task title", type: "string", required: true },
-      { name: "notes", description: "Free-text notes / body", type: "string", required: false },
-      { name: "status", description: "Task status: needsAction or completed", type: "string", required: false },
-      { name: "due", description: "Due date (RFC 3339)", type: "string", required: false },
-    ],
-  },
-  {
-    name: "tasks_tasks_patch",
-    description: "Update a task with patch semantics. Common use: complete a task by setting status to \"completed\".",
+    description: "Update a task (only supplied fields change). Common use: complete a task by setting status to \"completed\".",
     command: ["tasks", "tasks", "patch"],
     params: [
       { name: "tasklist", description: "Task list ID", type: "string", required: true },


### PR DESCRIPTION
I've experienced a few occasions where Claude tries to use `*_update` rather than `*_patch` tools when editing a task / task list, resulting in errors because it hasn't included the ID in the body (because it hasn't changed).

`tasks_tasks_update` and `tasks_tasklists_update` mapped to the Tasks API's PUT methods, which required a complete replacement of all fields, potentially leading to errors or dataloss.  This change routes both tools to the `*_patch` verb instead (partial update: only supplied fields change), make all body fields optional, and remove the now defunct `tasks_tasks_patch` and `tasks_tasklists_patch` tools so each resource has one safe update tool.  Note: this matches Drive v3's single-verb convention.

**Breaking Change**:  `tasks_tasks_patch` and `tasks_tasklists_patch` tools removed in favour of `tasks_tasks_update` and `tasks_tasklists_update`.