### PR TITLE
fix(calendar): route calendar_events_update to events.patch verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ npm install && npm run build
 - `calendar_events_list` — List events
 - `calendar_events_get` — Get event details
 - `calendar_events_insert` — Create events
-- `calendar_events_update` — Update events
+- `calendar_events_update` — Update events (only supplied fields change)
 - `calendar_events_delete` — Delete events
 
 ### `docs` (3 tools)

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getToolsForServices, SERVICE_TOOLS, ALL_SERVICES, buildAnnotations, type ToolDef } from "../services.js";
+import { buildArgs } from "../executor.js";
 
 describe("getToolsForServices", () => {
   it("returns tools for requested services", () => {
@@ -137,6 +138,40 @@ describe("tasks service shape", () => {
         expect(hasBody, `${tool.name} should not declare bodyParams`).toBe(false);
       }
     }
+  });
+});
+
+// ── Calendar event updates use patch semantics ───────────────────────────
+// The Calendar API's events.update (PUT) always replaces the entire event
+// and rejects bodies missing required event fields (e.g. "Missing end
+// time"), so partial calls through the old verb failed. The tool routes to
+// events.patch instead, where only supplied fields change.
+
+describe("calendar_events_update (patch semantics)", () => {
+  const tool = SERVICE_TOOLS["calendar"].find((t) => t.name === "calendar_events_update")!;
+
+  it("routes to the patch verb", () => {
+    expect(tool.command).toEqual(["calendar", "events", "patch"]);
+  });
+
+  it("all body fields are optional, so partial updates are schema-valid", () => {
+    for (const p of tool.bodyParams!) {
+      expect(p.required, `${p.name} must be optional`).toBe(false);
+    }
+  });
+
+  it("a summary-only call sends only summary in the body (start/end not required)", () => {
+    const args = buildArgs(tool, {
+      calendarId: "primary",
+      eventId: "evt123",
+      summary: "New title",
+    });
+    expect(args.slice(0, 3)).toEqual(["calendar", "events", "patch"]);
+    const jsonIdx = args.indexOf("--json");
+    expect(jsonIdx).toBeGreaterThan(-1);
+    // Body must contain exactly the supplied field — start/end/description
+    // stay untouched on the server.
+    expect(JSON.parse(args[jsonIdx + 1])).toEqual({ summary: "New title" });
   });
 });
 

--- a/src/services.ts
+++ b/src/services.ts
@@ -280,8 +280,8 @@ const calendarTools: ToolDef[] = [
   },
   {
     name: "calendar_events_update",
-    description: "Update an existing calendar event.",
-    command: ["calendar", "events", "update"],
+    description: "Update an existing calendar event with patch semantics (only supplied fields change).",
+    command: ["calendar", "events", "patch"],
     params: [
       { name: "calendarId", description: "Calendar ID", type: "string", required: true },
       { name: "eventId", description: "Event ID to update", type: "string", required: true },


### PR DESCRIPTION
`calendar_events_update` mapped to the Calendar API's `events.update` (PUT), which is designed to update the entire event resource.  Partial calls (e.g. renaming an event without resupplying start/end) failed with "Missing end time".

Similar to PR https://github.com/conorbronsdon/gws-mcp-server/pull/9, this now routes `calendar_events_update` to `events.patch`, where only supplied fields change.