### PR TITLE
test: make --json body assertions cross-platform

### DIFF
--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getToolsForServices, SERVICE_TOOLS, ALL_SERVICES, buildAnnotations, type ToolDef } from "../services.js";
-import { buildArgs } from "../executor.js";
+import { buildArgs, escapeJsonArg } from "../executor.js";
 
 describe("getToolsForServices", () => {
   it("returns tools for requested services", () => {
@@ -180,7 +180,9 @@ describe("tasks update tools (patch semantics)", () => {
     expect(jsonIdx).toBeGreaterThan(-1);
     // Body must contain exactly the supplied field — nothing injected that
     // would overwrite notes/status/due on the server.
-    expect(JSON.parse(args[jsonIdx + 1])).toEqual({ title: "New title" });
+    // Compare against the same escaping buildArgs applies, so this holds on
+    // Windows (cmd-escaped) as well as Linux/macOS (escapeJsonArg is a no-op).
+    expect(args[jsonIdx + 1]).toBe(escapeJsonArg(JSON.stringify({ title: "New title" })));
   });
 
   it("no separate *_patch tools remain (one safe update verb per resource)", () => {
@@ -219,7 +221,9 @@ describe("calendar_events_update (patch semantics)", () => {
     expect(jsonIdx).toBeGreaterThan(-1);
     // Body must contain exactly the supplied field — start/end/description
     // stay untouched on the server.
-    expect(JSON.parse(args[jsonIdx + 1])).toEqual({ summary: "New title" });
+    // Compare against the same escaping buildArgs applies, so this holds on
+    // Windows (cmd-escaped) as well as Linux/macOS (escapeJsonArg is a no-op).
+    expect(args[jsonIdx + 1]).toBe(escapeJsonArg(JSON.stringify({ summary: "New title" })));
   });
 });
 


### PR DESCRIPTION
## Problem

The `tasks_*_update` and `calendar_events_update` patch-semantics tests asserted `JSON.parse(args[jsonIdx + 1])`. That only works where `escapeJsonArg` is a no-op (Linux/macOS). On Windows, `escapeJsonArg` wraps the body via `escapeForCmd`, so `JSON.parse` returns a string and the assertions fail locally — even though the code is correct. CI (Linux) stayed green, so the gap was invisible until a contributor ran the suite on Windows.

## Fix

Assert against `escapeJsonArg(JSON.stringify(...))` — the exact serialization `buildArgs` emits — so the check matches on every platform. Still proves the body contains only the supplied field (any injected key would change the string).

## Verification
- `npm run build` (tsc) clean
- `npm test` → **190/190 pass on Windows** (previously 4 failed); remains green on Linux CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)