### PR TITLE
Add npm publish + release automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,69 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - package.json
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Check if package.json version is already published
+        id: version
+        run: |
+          LOCAL_VERSION="$(node -p "require('./package.json').version")"
+          PKG_NAME="$(node -p "require('./package.json').name")"
+          PUBLISHED_VERSION="$(npm view "$PKG_NAME" version 2>/dev/null || echo none)"
+          echo "local=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
+          echo "published=$PUBLISHED_VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$LOCAL_VERSION" = "$PUBLISHED_VERSION" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "package.json version ($LOCAL_VERSION) is already published — nothing to do."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "package.json version ($LOCAL_VERSION) differs from published ($PUBLISHED_VERSION) — publishing."
+          fi
+
+      - name: Install dependencies
+        if: steps.version.outputs.changed == 'true'
+        run: npm ci
+
+      - name: Build
+        if: steps.version.outputs.changed == 'true'
+        run: npm run build --if-present
+
+      - name: Test
+        if: steps.version.outputs.changed == 'true'
+        run: npm test --if-present
+
+      - name: Publish to npm
+        if: steps.version.outputs.changed == 'true'
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        if: steps.version.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.local }}"
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "Release v$VERSION already exists — skipping."
+          else
+            gh release create "v$VERSION" --target "$GITHUB_SHA" --generate-notes
+          fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml`: on push to `main` touching `package.json` (or manual `workflow_dispatch`), compares the local `package.json` version to what's published on npm. If they match, the workflow exits cleanly with a log line and does nothing. If they differ, it runs `npm ci`, `npm run build --if-present`, `npm test --if-present`, then `npm publish --provenance`, and finally creates a matching GitHub release (`gh release create vX.Y.Z --generate-notes`) if that tag doesn't already exist.
- `package.json` already has a correct `repository` field pointing at this repo, which npm provenance requires — no change needed there.
- Inert until the `NPM_TOKEN` secret is set on this repo.

## Note
`main` is currently ahead of npm: local version is `0.3.0`, published is `0.2.0`. Once `NPM_TOKEN` is set, running the workflow via `workflow_dispatch` (or the next push touching `package.json`) will publish `0.3.0` to npm and cut release `v0.3.0` automatically.

## Test plan
- [ ] YAML validated with `yaml.safe_load`
- [ ] Set `NPM_TOKEN` secret, then trigger via `workflow_dispatch` and confirm it publishes `0.3.0` and creates release `v0.3.0`