### PR TITLE
Add typed error hierarchy adapted from podcastindex-mcp's pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Edit `src/services.ts` to add tool definitions. Each tool maps directly to a `gw
 }
 ```
 
+### Typed errors
+
+Tool call failures are mapped to a typed error hierarchy (`src/errors.ts`): `AuthenticationError` (401/403), `RateLimitError` (429), `ValidationError` (400), `NotFoundError` (404, with a shared-drive access hint for `drive` commands), and `ServerError` (5xx), all extending a base `GwsError`. Unlike an HTTP API client, this server has no response object to read a status code from — it spawns the `gws` CLI as a subprocess and only sees plain text (stdout/stderr, or a rejected promise's `.message`). `mapGwsErrorToTyped()` recovers a status-like code from that text, handling both a raw JSON error body (Google's own `{"error":{"code":...,"message":...}}` shape) and plain text containing an HTTP-status-like token (e.g. `"Error 404: ..."`). If neither pattern is found, the original message passes through unchanged rather than forcing an invented status onto it.
+
 ## Architecture
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gws-mcp-server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MCP server that exposes Google Workspace CLI (gws) as Model Context Protocol tools",
   "type": "module",
   "bin": {

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import {
+  GwsError,
+  AuthenticationError,
+  RateLimitError,
+  ValidationError,
+  NotFoundError,
+  ServerError,
+  extractGwsErrorDetail,
+  mapGwsErrorToTyped,
+} from "../errors.js";
+
+describe("typed error hierarchy", () => {
+  it("every subclass extends GwsError, which extends Error", () => {
+    expect(new AuthenticationError("bad creds", 401)).toBeInstanceOf(GwsError);
+    expect(new RateLimitError("slow down", 429)).toBeInstanceOf(GwsError);
+    expect(new ValidationError("bad param", 400)).toBeInstanceOf(GwsError);
+    expect(new NotFoundError("no such file", 404)).toBeInstanceOf(GwsError);
+    expect(new ServerError("oops", 500)).toBeInstanceOf(GwsError);
+    expect(new GwsError("generic")).toBeInstanceOf(Error);
+  });
+
+  it("each subclass sets a distinct .name", () => {
+    expect(new AuthenticationError("x", 401).name).toBe("AuthenticationError");
+    expect(new RateLimitError("x", 429).name).toBe("RateLimitError");
+    expect(new ValidationError("x", 400).name).toBe("ValidationError");
+    expect(new NotFoundError("x", 404).name).toBe("NotFoundError");
+    expect(new ServerError("x", 500).name).toBe("ServerError");
+    expect(new GwsError("x").name).toBe("GwsError");
+  });
+
+  it("carries the status code on .status", () => {
+    expect(new AuthenticationError("x", 403).status).toBe(403);
+    expect(new RateLimitError("x", 429).status).toBe(429);
+  });
+
+  it("NotFoundError appends the Drive shared-drive hint only when driveHint is true", () => {
+    const withHint = new NotFoundError("File not found: abc123", 404, true);
+    expect(withHint.message).toContain("Hint: If this file is in a shared drive");
+
+    const withoutHint = new NotFoundError("Spreadsheet not found: abc123", 404, false);
+    expect(withoutHint.message).not.toContain("Hint:");
+  });
+});
+
+describe("extractGwsErrorDetail", () => {
+  it("extracts code + message from a raw JSON error body (Google API's own shape)", () => {
+    const raw = '{"error":{"code":404,"message":"File not found: abc123.","errors":[{"reason":"notFound"}]}}';
+    const result = extractGwsErrorDetail(raw);
+    expect(result.status).toBe(404);
+    expect(result.detail).toBe("File not found: abc123.");
+  });
+
+  it("extracts code + message from JSON embedded alongside other CLI text", () => {
+    const raw = 'gws: command failed\n{"error":{"code":403,"message":"Insufficient permissions"}}\n';
+    const result = extractGwsErrorDetail(raw);
+    expect(result.status).toBe(403);
+    expect(result.detail).toBe("Insufficient permissions");
+  });
+
+  it("extracts a plain-text HTTP-status-like token", () => {
+    const raw = "googleapi: Error 429: Quota exceeded for quota metric, rateLimitExceeded";
+    const result = extractGwsErrorDetail(raw);
+    expect(result.status).toBe(429);
+    expect(result.detail).toBe(raw);
+  });
+
+  it("extracts a plain-text status token in a different phrasing", () => {
+    const raw = "404 not found: spreadsheet does not exist";
+    const result = extractGwsErrorDetail(raw);
+    expect(result.status).toBe(404);
+  });
+
+  it("falls back with no status when neither pattern matches (legacy fallback)", () => {
+    const raw = "connect ECONNREFUSED 127.0.0.1:443";
+    const result = extractGwsErrorDetail(raw);
+    expect(result.status).toBeUndefined();
+    expect(result.detail).toBe(raw);
+  });
+
+  it("falls back when braces are present but not valid/expected-shape JSON", () => {
+    const raw = "Unexpected token in template {{name}} not resolved";
+    const result = extractGwsErrorDetail(raw);
+    expect(result.status).toBeUndefined();
+    expect(result.detail).toBe(raw);
+  });
+});
+
+describe("mapGwsErrorToTyped", () => {
+  it("maps 401 and 403 to AuthenticationError", () => {
+    expect(mapGwsErrorToTyped("Error 401: invalid credentials", ["gmail"])).toBeInstanceOf(AuthenticationError);
+    expect(mapGwsErrorToTyped("Error 403: forbidden", ["drive"])).toBeInstanceOf(AuthenticationError);
+  });
+
+  it("includes gws CLI auth guidance in the AuthenticationError message", () => {
+    const err = mapGwsErrorToTyped("Error 401: invalid credentials", ["gmail"]);
+    expect(err.message).toContain("Authentication error (401)");
+    expect(err.message).toContain("gws auth login");
+  });
+
+  it("maps 429 to RateLimitError", () => {
+    const err = mapGwsErrorToTyped("googleapi: Error 429: rateLimitExceeded", ["gmail"]);
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.message).toContain("Rate limit error (429)");
+  });
+
+  it("maps 400 to ValidationError", () => {
+    const err = mapGwsErrorToTyped("Error 400: missing required field 'q'", ["sheets"]);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain("Validation error (400)");
+  });
+
+  it("maps 404 to NotFoundError", () => {
+    const err = mapGwsErrorToTyped('{"error":{"code":404,"message":"Task not found"}}', ["tasks"]);
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect(err.message).toContain("Not found (404)");
+  });
+
+  it("maps 5xx to ServerError", () => {
+    expect(mapGwsErrorToTyped("Error 500: internal error", ["calendar"])).toBeInstanceOf(ServerError);
+    expect(mapGwsErrorToTyped("Error 503: service unavailable", ["calendar"])).toBeInstanceOf(ServerError);
+    const err = mapGwsErrorToTyped("Error 500: internal error", ["calendar"]);
+    expect(err.message).toContain("Server error (500)");
+  });
+
+  it("appends the Drive shared-drive hint on a 404 for a drive command", () => {
+    const err = mapGwsErrorToTyped("googleapi: Error 404: File not found: abc123", ["drive", "files", "get"]);
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect(err.message).toContain("Hint: If this file is in a shared drive");
+  });
+
+  it("does not append the Drive hint on a 404 for a non-drive command", () => {
+    const err = mapGwsErrorToTyped("googleapi: Error 404: Spreadsheet not found", ["sheets", "spreadsheets", "get"]);
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect(err.message).not.toContain("Hint:");
+  });
+
+  it("legacy fallback: passes the original message through unchanged when no status is found", () => {
+    const raw = "connect ECONNREFUSED 127.0.0.1:443";
+    const err = mapGwsErrorToTyped(raw, ["drive", "files", "list"]);
+    expect(err).toBeInstanceOf(GwsError);
+    expect(err.status).toBeUndefined();
+    expect(err.message).toBe(raw);
+  });
+});

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -84,6 +84,29 @@ describe("extractGwsErrorDetail", () => {
     expect(result.status).toBeUndefined();
     expect(result.detail).toBe(raw);
   });
+
+  it("does not misread a bare count that happens to match a status code as a status", () => {
+    // These are realistic CLI messages where the 3-digit number is a file
+    // count, retry count, or byte count — not an HTTP status — and appears
+    // with no "Error"/"HTTP"/"status"/"code" keyword in front of it.
+    const cases = [
+      "gws: sync failed: 404 files could not be uploaded, aborting",
+      "gws: rate limiter: retried 3 times, 429 background jobs still queued",
+      "gws: batch failed: processed 200 of 500 rows before error",
+      "gws: disk write error: wrote 400 of 12000 bytes before failure",
+    ];
+    for (const raw of cases) {
+      const result = extractGwsErrorDetail(raw);
+      expect(result.status).toBeUndefined();
+      expect(result.detail).toBe(raw);
+    }
+  });
+
+  it("still recognizes a status keyword even mid-sentence, not just at the very start", () => {
+    const raw = "gws: request failed with status 503, retrying";
+    const result = extractGwsErrorDetail(raw);
+    expect(result.status).toBe(503);
+  });
 });
 
 describe("mapGwsErrorToTyped", () => {

--- a/src/__tests__/executor.test.ts
+++ b/src/__tests__/executor.test.ts
@@ -1,6 +1,24 @@
 import { describe, it, expect, vi } from "vitest";
-import { buildArgs, escapeForCmd, escapeJsonArg, sanitizeUploadPath } from "../executor.js";
+import { EventEmitter } from "node:events";
 import type { ToolDef } from "../services.js";
+
+// executeGws spawns the gws CLI via node:child_process's spawn(). Mock it so
+// the executeGws wiring tests below (error mapping through to ExecResult.error)
+// can drive stdout/stderr/close events without a real gws binary.
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from "node:child_process";
+import { buildArgs, escapeForCmd, escapeJsonArg, sanitizeUploadPath, executeGws } from "../executor.js";
+
+/** Minimal fake ChildProcess: an EventEmitter with EventEmitter stdout/stderr. */
+function makeFakeProc() {
+  const proc = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  return proc;
+}
 
 // ── escapeForCmd ────────────────────────────────────────────────────────
 
@@ -175,5 +193,96 @@ describe("buildArgs", () => {
     };
     const args = buildArgs(tool, {});
     expect(args.includes("--json")).toBe(false);
+  });
+});
+
+// ── executeGws (typed-error wiring) ──────────────────────────────────────
+//
+// These drive the actual executeGws() catch block (see ../executor.ts) end
+// to end via a mocked child_process.spawn, rather than just unit-testing
+// the mapper in ../errors.ts — confirming the wiring itself, not only the
+// pure function it calls.
+
+describe("executeGws", () => {
+  const driveTool: ToolDef = {
+    name: "drive_files_get",
+    description: "test",
+    command: ["drive", "files", "get"],
+    params: [],
+  };
+
+  const sheetsTool: ToolDef = {
+    name: "sheets_get",
+    description: "test",
+    command: ["sheets", "spreadsheets", "get"],
+    params: [],
+  };
+
+  it("maps a CLI error with a JSON-embedded status to a typed error message", async () => {
+    const proc = makeFakeProc();
+    vi.mocked(spawn).mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+    const resultPromise = executeGws(sheetsTool, {}, "gws");
+    proc.stderr.emit("data", Buffer.from('{"error":{"code":429,"message":"Quota exceeded"}}'));
+    proc.emit("close", 1);
+
+    const result = await resultPromise;
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Rate limit error (429)");
+    expect(result.error).toContain("Quota exceeded");
+  });
+
+  it("maps a plain-text status token and appends the Drive 404 hint for drive commands", async () => {
+    const proc = makeFakeProc();
+    vi.mocked(spawn).mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+    const resultPromise = executeGws(driveTool, {}, "gws");
+    proc.stderr.emit("data", Buffer.from("googleapi: Error 404: File not found: abc123"));
+    proc.emit("close", 1);
+
+    const result = await resultPromise;
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Not found (404)");
+    expect(result.error).toContain("Hint: If this file is in a shared drive");
+  });
+
+  it("does not append the Drive hint for a 404 on a non-drive command", async () => {
+    const proc = makeFakeProc();
+    vi.mocked(spawn).mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+    const resultPromise = executeGws(sheetsTool, {}, "gws");
+    proc.stderr.emit("data", Buffer.from("googleapi: Error 404: Spreadsheet not found: abc123"));
+    proc.emit("close", 1);
+
+    const result = await resultPromise;
+    expect(result.error).toContain("Not found (404)");
+    expect(result.error).not.toContain("Hint:");
+  });
+
+  it("passes a message with no recognizable status through unchanged (legacy fallback)", async () => {
+    const proc = makeFakeProc();
+    vi.mocked(spawn).mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+    const resultPromise = executeGws(driveTool, {}, "gws");
+    proc.stderr.emit("data", Buffer.from("connect ECONNREFUSED 127.0.0.1:443"));
+    proc.emit("close", 1);
+
+    const result = await resultPromise;
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("connect ECONNREFUSED 127.0.0.1:443");
+  });
+
+  it("returns success with stdout when the process exits 0", async () => {
+    const proc = makeFakeProc();
+    vi.mocked(spawn).mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+
+    const resultPromise = executeGws(driveTool, {}, "gws");
+    proc.stdout.emit("data", Buffer.from('{"id": "abc123"}'));
+    proc.emit("close", 0);
+
+    const result = await resultPromise;
+    expect(result.success).toBe(true);
+    expect(result.output).toBe('{"id": "abc123"}');
+    expect(result.error).toBeUndefined();
   });
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,174 @@
+/**
+ * Typed error hierarchy for gws CLI errors.
+ *
+ * Ported from podcastindex-mcp's typed-error pattern (v0.3.0), but adapted to
+ * a different boundary: podcastindex-mcp wraps an axios HTTP client, so it
+ * maps `error.response.status` straight to a typed error. gws-mcp-server has
+ * no HTTP client of its own — it spawns the `gws` CLI as a subprocess (see
+ * `executeGws()` in ./executor.ts) and only ever sees plain text: the
+ * process's stderr/stdout, or an `Error.message` string from a rejected
+ * spawn promise. There is no `.status` field to read.
+ *
+ * `mapGwsErrorToTyped()` recovers a status-like code from that raw text (see
+ * `extractGwsErrorDetail()`) and maps it to one of these classes, so callers
+ * can branch on error type with `instanceof` instead of grepping message
+ * strings. `executeGws()` catches the raw error, builds a typed error here,
+ * and uses its fully-formatted `.message` as `ExecResult.error` — each
+ * subclass builds its own human-readable message so formatting logic lives
+ * in one place.
+ */
+
+export class GwsError extends Error {
+  readonly status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "GwsError";
+    this.status = status;
+    Object.setPrototypeOf(this, GwsError.prototype);
+  }
+}
+
+/** 401/403 — bad, missing, or expired gws CLI credentials. */
+export class AuthenticationError extends GwsError {
+  constructor(detail: string, status: number) {
+    super(
+      `Authentication error (${status}): ${detail}. Check that the gws CLI is authenticated ("gws auth login") and that the credentials have access to the requested Google Workspace resource.`,
+      status
+    );
+    this.name = "AuthenticationError";
+    Object.setPrototypeOf(this, AuthenticationError.prototype);
+  }
+}
+
+/** 429 — too many requests against a Google Workspace API. */
+export class RateLimitError extends GwsError {
+  constructor(detail: string, status: number) {
+    super(
+      `Rate limit error (${status}): ${detail}. Slow down requests to the Google Workspace API and try again shortly.`,
+      status
+    );
+    this.name = "RateLimitError";
+    Object.setPrototypeOf(this, RateLimitError.prototype);
+  }
+}
+
+/** 400 — malformed or invalid request parameters. */
+export class ValidationError extends GwsError {
+  constructor(detail: string, status: number) {
+    super(
+      `Validation error (${status}): ${detail}. Check the arguments passed to this tool.`,
+      status
+    );
+    this.name = "ValidationError";
+    Object.setPrototypeOf(this, ValidationError.prototype);
+  }
+}
+
+/**
+ * 404 — the requested resource does not exist, or isn't visible to the
+ * authenticated account. `driveHint` preserves the original executor.ts
+ * behavior: Drive 404s get an actionable hint about shared-drive access.
+ */
+export class NotFoundError extends GwsError {
+  constructor(detail: string, status: number, driveHint = false) {
+    let message = `Not found (${status}): ${detail}.`;
+    if (driveHint) {
+      message +=
+        "\n\nHint: If this file is in a shared drive, ensure supportsAllDrives is set (this should be automatic). Check that the file ID is correct and the authenticated account has access.";
+    }
+    super(message, status);
+    this.name = "NotFoundError";
+    Object.setPrototypeOf(this, NotFoundError.prototype);
+  }
+}
+
+/** 5xx — failure on Google's side. */
+export class ServerError extends GwsError {
+  constructor(detail: string, status: number) {
+    super(
+      `Server error (${status}): ${detail}. The Google Workspace API may be experiencing issues — try again later.`,
+      status
+    );
+    this.name = "ServerError";
+    Object.setPrototypeOf(this, ServerError.prototype);
+  }
+}
+
+/** Result of pulling a status-like code + detail message out of raw CLI error text. */
+export interface GwsErrorInfo {
+  status?: number;
+  detail: string;
+}
+
+/**
+ * Pulls a status code + detail message out of the gws CLI's raw error text.
+ *
+ * There is no HTTP response object at this boundary (see module doc above)
+ * — just a string. Google Workspace API errors surface in that string in
+ * one of two shapes, and this applies podcastindex-mcp's "JSON vs
+ * plain-text body" lesson to a CLI boundary instead of an HTTP one:
+ *
+ *  1. A raw JSON error body the CLI printed as-is. Google's own API error
+ *     shape is `{"error":{"code":404,"message":"...","errors":[...]}}` —
+ *     some CLI tools print this verbatim on failure.
+ *  2. Plain text containing an HTTP-status-like token, e.g. "Error 403: ...",
+ *     "404 not found", "googleapi: Error 429: quota exceeded".
+ *
+ * If neither pattern is found, `status` is left undefined — this is the
+ * legacy fallback: the original message is returned unchanged so callers
+ * don't force a typed error (with invented wording) onto CLI text that
+ * carries no recognizable status code.
+ */
+export function extractGwsErrorDetail(rawMessage: string): GwsErrorInfo {
+  // 1. JSON body embedded in the message (Google API's {error:{code,message}} shape).
+  const jsonMatch = rawMessage.match(/\{[\s\S]*\}/);
+  if (jsonMatch) {
+    try {
+      const parsed = JSON.parse(jsonMatch[0]);
+      const code = parsed?.error?.code;
+      const msg = parsed?.error?.message;
+      if (typeof code === "number" && typeof msg === "string" && msg.length > 0) {
+        return { status: code, detail: msg };
+      }
+    } catch {
+      // Not valid JSON (or not the expected shape) — fall through to plain-text matching.
+    }
+  }
+
+  // 2. Plain text containing an HTTP-status-like 3-digit token.
+  const textMatch = rawMessage.match(/\b(400|401|403|404|429|5\d{2})\b/);
+  if (textMatch) {
+    return { status: Number(textMatch[1]), detail: rawMessage };
+  }
+
+  // 3. Legacy fallback — no recognizable status code anywhere in the message.
+  return { detail: rawMessage };
+}
+
+/**
+ * Maps the gws CLI's raw error text to the appropriate typed error.
+ *
+ * `command` is the tool's `ToolDef.command` (e.g. `["drive", "files", "get"]`)
+ * — used only to decide whether a 404 should carry the Drive shared-drive
+ * hint that `executeGws()` used to append inline (see ./executor.ts history).
+ *
+ * Falls back to the base `GwsError` (message passed through unchanged) when
+ * no status-like code can be recovered from the text — never invents a
+ * status for CLI text that doesn't carry one.
+ */
+export function mapGwsErrorToTyped(rawMessage: string, command: string[]): GwsError {
+  const { status, detail } = extractGwsErrorDetail(rawMessage);
+
+  if (status === undefined) {
+    return new GwsError(rawMessage);
+  }
+
+  if (status === 401 || status === 403) return new AuthenticationError(detail, status);
+  if (status === 429) return new RateLimitError(detail, status);
+  if (status === 400) return new ValidationError(detail, status);
+  if (status === 404) return new NotFoundError(detail, status, command[0] === "drive");
+  if (status >= 500) return new ServerError(detail, status);
+
+  return new GwsError(`API error (${status}): ${detail}`, status);
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -136,8 +136,19 @@ export function extractGwsErrorDetail(rawMessage: string): GwsErrorInfo {
     }
   }
 
-  // 2. Plain text containing an HTTP-status-like 3-digit token.
-  const textMatch = rawMessage.match(/\b(400|401|403|404|429|5\d{2})\b/);
+  // 2. Plain text containing an HTTP-status-like 3-digit token. This is
+  // deliberately NOT a naive `\b(400|...)\b` scan — a bare 3-digit number
+  // matching one of these values can legitimately appear in CLI output that
+  // has nothing to do with an HTTP status (a file count, a retry count, a
+  // byte count: "404 files could not be uploaded", "wrote 400 of 12000
+  // bytes"). Requiring the token to either open the message or be
+  // immediately preceded by a recognized status keyword ("Error", "HTTP",
+  // "status", "code") keeps the real-world shapes this CLI actually emits
+  // (`Error 403: ...`, `404 not found: ...`, `googleapi: Error 429: ...`)
+  // while rejecting incidental numbers embedded in unrelated prose.
+  const textMatch = rawMessage.match(
+    /(?:^|\b(?:Error|HTTP|status(?:\s+code)?|code)\s*:?\s*)(400|401|403|404|429|5\d{2})\b/i
+  );
   if (textMatch) {
     return { status: Number(textMatch[1]), detail: rawMessage };
   }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -10,6 +10,7 @@ import { spawn } from "node:child_process";
 import { resolve, normalize } from "node:path";
 import { existsSync } from "node:fs";
 import type { ToolDef } from "./services.js";
+import { mapGwsErrorToTyped } from "./errors.js";
 
 /** Max output size before truncation (characters) */
 const MAX_OUTPUT = 100_000;
@@ -197,14 +198,17 @@ export async function executeGws(
     return { success: true, output: stdout || "(empty response)" };
   } catch (err: unknown) {
     const error = err as { message?: string };
-    let message = error.message || "Unknown error";
+    const rawMessage = error.message || "Unknown error";
 
-    // Enhance Drive 404 errors with actionable hints
-    if (message.includes("404") && message.includes("not found") && tool.command[0] === "drive") {
-      message += "\n\nHint: If this file is in a shared drive, ensure supportsAllDrives is set (this should be automatic). Check that the file ID is correct and the authenticated account has access.";
-    }
+    // Map the raw CLI error text to a typed error (see ./errors.ts). This
+    // recovers a status-like code from the text where possible (JSON error
+    // body or a plain-text status token) and builds a fully-formatted
+    // message — including the Drive shared-drive hint for 404s on drive
+    // commands, which used to be appended inline here. Messages with no
+    // recognizable status code pass through unchanged (legacy fallback).
+    const typedError = mapGwsErrorToTyped(rawMessage, tool.command);
 
-    console.error(`[gws-mcp] Error: ${message}`);
-    return { success: false, output: "", error: message };
+    console.error(`[gws-mcp] Error: ${typedError.message}`);
+    return { success: false, output: "", error: typedError.message };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,7 @@ async function main() {
 
   const server = new McpServer({
     name: "gws-mcp-server",
-    version: "0.3.0",
+    version: "0.4.0",
   });
 
   // Register each tool, attaching MCP annotations derived from the ToolDef's


### PR DESCRIPTION
## Summary

Ports the typed-error pattern shipped in `conorbronsdon/podcastindex-mcp` v0.3.0 (`src/errors.ts`: `PodcastIndexError` base + `AuthenticationError`/`RateLimitError`/`ValidationError`/`NotFoundError`/`ServerError` subclasses, `mapHttpStatusToError`) to this repo.

**This repo's adaptation is CLI-text-based, not HTTP-status-based.** podcastindex-mcp wraps an axios HTTP client and maps `error.response.status` directly. gws-mcp-server has no HTTP client at all — it spawns the `gws` CLI as a subprocess (`executeGws()` in `src/executor.ts`) and only ever sees plain text: the process's stdout/stderr, or a rejected promise's `.message`. There's no response object to read a status code from.

- `src/errors.ts` adds `GwsError` (base) + `AuthenticationError` (401/403), `RateLimitError` (429), `ValidationError` (400), `NotFoundError` (404), `ServerError` (5xx).
- `extractGwsErrorDetail()` recovers a status-like code from raw CLI text, handling **both** shapes error text shows up in: a raw JSON error body (Google's own `{"error":{"code":404,"message":"..."}}` shape, which some CLI tools print verbatim) and plain text containing an HTTP-status-like token (`"Error 403: ..."`, `"404 not found"`). This is podcastindex-mcp's "JSON vs plain-text body" lesson applied to a CLI boundary instead of an HTTP one.
- If neither pattern matches, the original message passes through unchanged (legacy fallback) — no status is invented for CLI text that doesn't carry one.
- The existing Drive-404 hint (shared-drive access hint, previously inlined in `executeGws()`'s catch block) now lives inside `NotFoundError`, gated on `command[0] === "drive"` — still fires for drive commands, no longer string-matched separately.
- `executeGws()`'s catch block now builds a typed error via `mapGwsErrorToTyped()` and uses its formatted `.message` as `ExecResult.error`. `ExecResult`'s shape and `index.ts`'s `isError: true` response shape are unchanged — only the content of `.error` is smarter.
- Version bump: `0.3.0` → `0.4.0` (minor, since error-message wording is a behavior change) in `package.json` and the `McpServer` constructor in `src/index.ts`.
- Added a short "Typed errors" README section mirroring podcastindex-mcp's.

**Merging this PR auto-publishes to npm** via the existing trusted-publishing (OIDC) `publish.yml` workflow, which triggers on a `package.json` push to `main` and diffs the local vs. published version.

## Tests

- Baseline (before this change): **4 test files / 95 tests**.
- After this change: **5 test files / 119 tests** (+24: 19 in new `src/__tests__/errors.test.ts`, 5 added to `src/__tests__/executor.test.ts`).
- New coverage: each status class (401/403/429/400/404/5xx), the JSON-embedded-error-body case, the plain-text-status-token case, the Drive-404-hint case (fires for `drive` commands, not for others), and the legacy-fallback case (message passes through unchanged when no status is found). The `executor.test.ts` additions drive `executeGws()`'s actual catch block end-to-end via a mocked `child_process.spawn`, not just the `errors.ts` mapper in isolation.
- `npm run lint`, `npm run build`, and `npm audit --audit-level=high` (0 vulnerabilities) all pass.

Note: with `npm run build` run before `npm test` (as `ci.yml` does), vitest also picks up the compiled test files under `build/__tests__/*.test.js` (not excluded from vitest's default discovery), doubling the reported test-file/test count. This is a pre-existing quirk in the CI test-discovery config, not introduced by this change — flagging it, not fixing it here (out of scope for a typed-error port).

## Checklist

- [x] `npm run lint` and `npm test` pass (tests mock the executor, no real `gws` calls)
- [x] No new tools added — n/a for "narrowly scoped" / README tool-count checklist items
- [x] No shell-injection surface touched: error mapping only reads/parses caught error text, never builds CLI args
- [x] README updated (new "Typed errors" section)