### PR TITLE
ci: fix publish (Node 24 base, drop fragile npm self-upgrade)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,9 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          # Node 24 ships npm >=11.5.1 with sigstore intact; self-upgrading npm on the
+          # Node 22 runner broke provenance publish ("Cannot find module sigstore").
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Check if package.json version is already published
@@ -50,9 +52,9 @@ jobs:
         if: steps.version.outputs.changed == 'true'
         run: npm test --if-present
 
-      - name: Update npm for trusted publishing
+      - name: Show tool versions
         if: steps.version.outputs.changed == 'true'
-        run: npm install -g npm@latest
+        run: node --version && npm --version
 
       - name: Publish to npm
         if: steps.version.outputs.changed == 'true'


### PR DESCRIPTION
Pre-emptive fix: the shared trusted-publishing workflow's `npm install -g npm@latest` step self-upgrades npm 10→11 on the Node 22 runner and leaves provenance's `sigstore` dependency unresolvable → `npm publish --provenance` dies with `Cannot find module 'sigstore'`. This was hit and **verified fixed** on `substack-mcp` (0.5.0 published successfully on Node 24).

**Fix:** run the publish job on **Node 24** (bundled npm ≥11.5.1 with `sigstore` intact) and drop the in-place upgrade. Keeps `--provenance` + OIDC trusted publishing; adds a version echo for diagnostics. No functional change; publish still only fires on a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)