### PR TITLE
ci: gate npm audit on critical, not high

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm run build
       - run: npm test
       # Keep installs green: block CI on high+ advisories, let moderates through.
-      - run: npm audit --audit-level=high
+      - run: npm audit --audit-level=critical
 
   # Stable aggregation gate: branch protection requires only this one check, so
   # editing the test matrix (OS/node) never orphans a required check name again.


### PR DESCRIPTION
A required `npm audit --audit-level=high` check fails on newly published advisories with no code change, so any transitive high-severity CVE blocks every PR including docs-only ones. That happened 2026-07-29: two one-line README PRs sat blocked on axios/fast-uri advisories until the lockfile was bumped. Critical still gates on what is worth gating; high findings stay visible in the job log without blocking merges.