### PR TITLE
Add UTM tags to chainofthought.show and conorbronsdon.com links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, and Tasks 
 [![npm version](https://img.shields.io/npm/v/gws-mcp-server?style=flat-square)](https://www.npmjs.com/package/gws-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Node](https://img.shields.io/badge/Node-18+-339933?style=flat-square&logo=node.js&logoColor=white)](https://nodejs.org/)
-[![Podcast](https://img.shields.io/badge/Podcast-Chain_of_Thought-purple?style=flat-square)](https://chainofthought.show)
+[![Podcast](https://img.shields.io/badge/Podcast-Chain_of_Thought-purple?style=flat-square)](https://chainofthought.show/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=gws-mcp-server)
 [![X](https://img.shields.io/badge/X-@ConorBronsdon-black?style=flat-square&logo=x)](https://x.com/ConorBronsdon)
 
 <img src="docs/demo.gif" alt="Demo: an agent calls the calendar_events_list tool and gets events back (sample data)" width="800">
@@ -183,7 +183,7 @@ Issues and pull requests are welcome. The most useful contributions are new tool
 
 ## About
 
-Built and maintained by [Conor Bronsdon](https://github.com/conorbronsdon). I host the [Chain of Thought](https://chainofthought.show) podcast, which covers AI infrastructure, developer tools, and how practitioners actually use this stuff. I built this to give the agent workflows that run the show safe, curated access to Gmail, Calendar, Drive, Sheets, Docs, and Tasks.
+Built and maintained by [Conor Bronsdon](https://github.com/conorbronsdon). I host the [Chain of Thought](https://chainofthought.show/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=gws-mcp-server) podcast, which covers AI infrastructure, developer tools, and how practitioners actually use this stuff. I built this to give the agent workflows that run the show safe, curated access to Gmail, Calendar, Drive, Sheets, Docs, and Tasks.
 
 <a href="https://glama.ai/mcp/servers/conorbronsdon/gws-mcp-server">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/conorbronsdon/gws-mcp-server/badge" alt="gws-mcp-server MCP server" />
@@ -197,7 +197,7 @@ Companion tools:
 - [op3-mcp](https://github.com/conorbronsdon/op3-mcp): podcast analytics through OP3. Downloads, geography, apps. Read-only.
 - [ai-tools-for-creators](https://github.com/conorbronsdon/ai-tools-for-creators): a curated list of AI skills and MCP servers for people who ship ideas for a living.
 
-More at [chainofthought.show](https://chainofthought.show) and on [X](https://x.com/ConorBronsdon).
+More at [chainofthought.show](https://chainofthought.show/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=gws-mcp-server) and on [X](https://x.com/ConorBronsdon).
 
 ---
 


### PR DESCRIPTION
Part of the repo-wide sweep in conorbronsdon/cot-production#115.

Tags the 3 link(s) in this repo's markdown so referral traffic to the show and to conorbronsdon.com is attributable:

```
?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=gws-mcp-server
```

Untagged, every repo's About footer and Chain of Thought badge lands in GA4's **Direct** bucket, indistinguishable from every other repo. `utm_content` carries the repo name so this one reports as its own row.

Applied by `scripts/utm-tag-links.py` in cot-production; `--check` exits 0 on this branch. Link targets and anchor text are unchanged — only the query string is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)