### PR TITLE
ci: publish to the MCP registry, not just npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,52 @@ jobs:
         if: steps.version.outputs.changed == 'true'
         run: npm publish --provenance
 
+      # server.json is derived from package.json at publish time so the two can
+      # never drift again — the registry stayed pinned at the June 2026 versions
+      # because server.json was hand-maintained and nobody re-published it.
+      - name: Sync server.json version from package.json
+        run: |
+          node -e '
+            const fs = require("fs");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            const server = JSON.parse(fs.readFileSync("server.json", "utf8"));
+            server.version = pkg.version;
+            for (const p of server.packages || []) p.version = pkg.version;
+            fs.writeFileSync("server.json", JSON.stringify(server, null, 2) + "\n");
+          '
+          node -p "\"server.json is now at \" + require('./server.json').version"
+
+      # Checked independently of the npm gate above: npm and the registry can be
+      # out of sync on their own, so a workflow_dispatch has to be able to push a
+      # registry-only catch-up without an npm version bump.
+      - name: Check if version is already in the MCP registry
+        id: registry
+        run: |
+          SERVER_NAME="$(node -p "require('./package.json').mcpName")"
+          LOCAL_VERSION="${{ steps.version.outputs.local }}"
+          if curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=$SERVER_NAME" -o registry.json; then
+            REGISTRY_VERSION="$(SERVER_NAME="$SERVER_NAME" node -p "const r = JSON.parse(require('fs').readFileSync('registry.json', 'utf8')).servers || []; const m = r.find(s => s.server && s.server.name === process.env.SERVER_NAME); m ? m.server.version : 'none'")"
+          else
+            REGISTRY_VERSION=unknown
+            echo "Registry lookup failed — will attempt the publish and let it decide."
+          fi
+          rm -f registry.json
+          if [ "$LOCAL_VERSION" = "$REGISTRY_VERSION" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "MCP registry already has $SERVER_NAME@$LOCAL_VERSION — nothing to do."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "MCP registry has $REGISTRY_VERSION, package.json is $LOCAL_VERSION — publishing."
+          fi
+
+      - name: Publish to the MCP registry
+        if: steps.registry.outputs.changed == 'true'
+        # Pinned: an unpinned /latest/ URL silently changes the CLI under CI.
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.8.0/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
+
       - name: Create GitHub release
         if: steps.version.outputs.changed == 'true'
         env:

--- a/server.json
+++ b/server.json
@@ -7,24 +7,26 @@
     "url": "https://github.com/conorbronsdon/gws-mcp-server",
     "source": "github"
   },
-  "version": "0.3.0",
+  "version": "0.4.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "gws-mcp-server",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
       },
       "packageArguments": [
         {
+          "type": "named",
           "name": "--services",
           "description": "Comma-separated list of Google services to expose (drive,sheets,calendar,docs,gmail,tasks). Defaults to all.",
           "isRequired": false,
           "default": "drive,sheets,calendar,docs,gmail,tasks"
         },
         {
+          "type": "named",
           "name": "--gws-path",
           "description": "Path to the gws binary if not on PATH.",
           "isRequired": false


### PR DESCRIPTION
The MCP registry has been frozen at the June 2026 publish while npm moved 2-3 minor versions ahead. Root cause: `publish.yml` publishes to npm and cuts a GitHub release, but **never calls `mcp-publisher`**. Nothing has ever updated the registry.

That matters more than one stale listing — PulseMCP, Glama, and LobeHub all auto-ingest from the registry, so one fix corrects every downstream directory permanently.

## Changes

1. **`server.json` synced to `package.json`**, plus a step that derives `version` and every `packages[].version` from `package.json` at publish time so it cannot drift again.
2. **A registry publish step** (`mcp-publisher`, `login github-oidc`) after npm publish, gated on its own registry-version check.

## Why the registry step has its own gate

The existing `changed` gate compares `package.json` to **npm**, which today says `changed=false` in every one of these repos. Hanging the registry step off it would have made this fix inert — no `workflow_dispatch` could repair the frozen registry, and drift would persist until the next version bump. The new check queries the registry directly, so a manual dispatch now performs a registry-only catch-up.

## Notes

- `mcp-publisher` pinned to **v1.8.0** rather than tracking `latest`; `curl -f` added so a bad URL fails instead of piping an HTML error page into `tar`.
- Duplicate versions are **skipped, not swallowed** — check-then-skip matches what the GitHub release step already does. A real failure (auth, schema rejection) still fails loudly, which is the point given that silent non-publishing is the bug.
- `id-token: write` was already present for npm provenance, confirmed per repo. No permissions changes.
- Small race worth knowing: `mcp-publisher` validates that the npm package carries a matching `mcpName`, so on a run where npm publish just happened there may be brief propagation lag. Re-dispatching succeeds.

Verified: YAML parsed and schema-validated against the committed blobs, `mcpName` matches `server.json` `name` in-repo and via `npm view`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)