### PR TITLE
readme: the token this asks for is broader than the tools it exposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,23 @@ The `gws` CLI had a built-in MCP server that was [removed in v0.8.0](https://git
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) 18+
-- [`gws` CLI](https://github.com/googleworkspace/cli) installed and authenticated (`npm install -g @googleworkspace/cli && gws auth login`)
+- [`gws` CLI](https://github.com/googleworkspace/cli) installed and authenticated (`npm install -g @googleworkspace/cli && gws auth login`)
+
+### Grant fewer scopes than the default
+
+This server exposes **no send tool** — the closest thing is `gmail_drafts_create`, which explicitly does not send. The token `gws auth login` mints is broader than that.
+
+`gws auth login` opens a scope picker with **nine** scopes pre-selected, including `gmail.modify` (Google documents it as "Read, compose, and send emails"), full read-write `drive`, and `cloud-platform`. Pressing Enter accepts all of them. Run non-interactively and you get `DEFAULT_SCOPES`, which is the same list minus the picker.
+
+So the token on disk can send mail and rewrite Drive even though nothing here will. **Deselect what you do not need in the picker**, or:
+
+```bash
+gws auth login --readonly    # read-only across services
+```
+
+One trap worth knowing: `-s gmail` does **not** narrow the picker to Gmail alone. `cloud-platform` is treated as a cross-service scope and is always included, pre-selected — deselect it manually if you use that flag.
+
+**On Linux, the encryption key sits beside the credentials it encrypts.** The `gws` credential store writes `.encryption_key` to `~/.config/gws/` and keeps it in sync with the keyring so credentials survive keyring loss; its own source says the file is never deleted. On macOS and Windows the key file is removed once the OS keyring holds it. If you are running this headless on Linux, treat `~/.config/gws/` as equivalent to a password file.
 
 ## Quick start
 


### PR DESCRIPTION
Setup said `gws auth login` and nothing else. Found while fact-checking an article that criticised this repo on exactly this point — the criticism was correct, and in one respect it was too soft.

## The gap

This server has **no send tool**. `gmail_drafts_create` explicitly documents that it does not send.

But `gws auth login` opens a scope picker with **nine** scopes **pre-selected** — including `gmail.modify` (Google: *"Read, compose, and send emails"*), full read-write `drive`, and `cloud-platform`. Pressing Enter accepts all of them. Non-interactively you get `DEFAULT_SCOPES`, the same list without the picker.

So someone following our setup ends up holding a token that can send mail and rewrite Drive, in order to run a server that will do neither — and nothing here said so.

## Two traps now documented

**`-s gmail` does not narrow to Gmail.** `scope_matches_service` returns `true` unconditionally for `cloud-platform` (`auth_commands.rs:820-823`, commented *"cloud-platform is a cross-service scope, always include"*). It shows up pre-selected. Recommending that flag as a scope-narrowing mitigation without saying so would have been actively misleading, which is why it's called out rather than just suggested.

**On Linux the encryption key sits beside the credentials it encrypts.** The credential store writes `.encryption_key` to `~/.config/gws/` and re-syncs it so credentials survive keyring loss (`credential_store.rs:268-271`); its own doc comment says the file is **never deleted** (line 194). macOS and Windows remove it once the OS keyring holds it. Linux is the common case for headless self-hosted deployments, so the README now says to treat that directory as equivalent to a password file.

All claims verified against `googleworkspace/cli` source, not inferred.

Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)