### PR TITLE
readme: there is no keyring on Linux, so the key file is the key

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ gws auth login --readonly    # read-only across services
 
 One trap worth knowing: `-s gmail` does **not** narrow the picker to Gmail alone. `cloud-platform` is treated as a cross-service scope and is always included, pre-selected — deselect it manually if you use that flag.
 
-**On Linux, the encryption key sits beside the credentials it encrypts.** The `gws` credential store writes `.encryption_key` to `~/.config/gws/` and keeps it in sync with the keyring so credentials survive keyring loss; its own source says the file is never deleted. On macOS and Windows the key file is removed once the OS keyring holds it. If you are running this headless on Linux, treat `~/.config/gws/` as equivalent to a password file.
+**On Linux there is no keyring, and the encryption key is a file next to the data it encrypts.** `gws` enables the `keyring` crate's native backends only for macOS and Windows; on every other platform the dependency is declared with no backend feature, so the store falls through to writing `.encryption_key` into `~/.config/gws/`. That file is not a backup of a key held elsewhere — it is the key, and the credential store's own doc comment says it is never deleted. Setting `GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND=file` changes nothing there because that is already the only path. On macOS and Windows the key file is removed once the OS keyring holds the key. **If you run this headless on Linux, treat `~/.config/gws/` as a password file: anyone who can read the directory has the credentials.**
 
 ## Quick start
 


### PR DESCRIPTION
Correcting the security paragraph merged in #22 an hour ago. It said the key file is kept *"in sync with the keyring so credentials survive keyring loss."*

**On Linux there is no keyring to lose.** `gws` enables the `keyring` crate's native backends for macOS and Windows only:

```toml
# Cargo.toml
[target.'cfg(target_os = "macos")'.dependencies]
keyring = { version = "3.6.3", features = ["apple-native"] }
[target.'cfg(target_os = "windows")'.dependencies]
keyring = { version = "3.6.3", features = ["windows-native"] }
[target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]
keyring = "3.6.3"
```

No backend feature on the third. So `.encryption_key` is not a backup of a key held somewhere safer — **it is the key**, in the same directory as the ciphertext, and the credential store's own doc comment says it is never deleted.

Two consequences the old wording got wrong:

- `GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND=file` **changes nothing on Linux.** The previous text implied it was the opt-in to this behaviour; it's a description of the only behaviour.
- Linux is the common case for the headless self-hosted deployments this section addresses, so this is the platform where the warning matters most and where the old paragraph was softest.

Caught while an agent fact-checked an article making the same claim against source rather than against my summary.