### PR TITLE
Advertise additive writes as non-destructive instead of relying on the MCP default

### DIFF
--- a/src/__tests__/annotations.e2e.test.ts
+++ b/src/__tests__/annotations.e2e.test.ts
@@ -1,0 +1,91 @@
+/**
+ * End-to-end annotation checks against an assembled server.
+ *
+ * `services.test.ts` covers `buildAnnotations`, but that function only sees
+ * registry tools. `drive_files_download` and `gmail_drafts_create` are
+ * registered by hand with annotation object literals, so a unit test over the
+ * builder cannot see them — which is how `gmail_drafts_create` shipped
+ * advertising itself as destructive. These tests drive a real MCP client over
+ * an in-memory transport and assert on the `tools/list` payload a client
+ * actually receives.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../index.js";
+import { getToolsForServices, ALL_SERVICES } from "../services.js";
+
+type ListedTool = {
+  name: string;
+  annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean };
+};
+
+let tools: ListedTool[];
+
+beforeAll(async () => {
+  const server = createServer(
+    getToolsForServices(ALL_SERVICES),
+    ALL_SERVICES,
+    "gws",
+    // gwsAvailable: nothing is executed here, only the tool list is read.
+    false,
+  );
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "annotations-test", version: "1.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  tools = (await client.listTools()).tools as ListedTool[];
+});
+
+const byName = (n: string): ListedTool => {
+  const t = tools.find((x) => x.name === n);
+  if (!t) throw new Error(`tool not registered: ${n}`);
+  return t;
+};
+
+describe("advertised annotations", () => {
+  it("registers both hand-written tools alongside the registry tools", () => {
+    expect(tools.length).toBe(39);
+    expect(byName("drive_files_download")).toBeDefined();
+    expect(byName("gmail_drafts_create")).toBeDefined();
+  });
+
+  it("no advertised write omits destructiveHint", () => {
+    // The regression. MCP defaults destructiveHint to true, so an omitted hint
+    // on a write advertises it as destructive to every client.
+    const writes = tools.filter((t) => t.annotations?.readOnlyHint === false);
+    expect(writes.length).toBeGreaterThan(0);
+    const omitted = writes
+      .filter((t) => typeof t.annotations?.destructiveHint !== "boolean")
+      .map((t) => t.name);
+    expect(omitted).toEqual([]);
+  });
+
+  it("gmail_drafts_create is advertised as a non-destructive write", () => {
+    // The README's safety argument rests on this tool never sending mail.
+    expect(byName("gmail_drafts_create").annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+    });
+  });
+
+  it("drive_files_download is advertised read-only (savePath writes locally, not to Drive)", () => {
+    expect(byName("drive_files_download").annotations?.readOnlyHint).toBe(true);
+  });
+
+  it("only irreversible removals are advertised as destructive", () => {
+    // tasks_tasks_clear is in this list and is not a *_delete: it permanently
+    // removes completed tasks from a list, so it belongs here.
+    const destructive = tools
+      .filter((t) => t.annotations?.destructiveHint === true)
+      .map((t) => t.name)
+      .sort();
+    expect(destructive).toEqual([
+      "calendar_events_delete",
+      "drive_files_delete",
+      "tasks_tasklists_delete",
+      "tasks_tasks_clear",
+      "tasks_tasks_delete",
+    ]);
+  });
+});

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -249,10 +249,12 @@ describe("buildAnnotations mapping", () => {
     expect(a).toEqual({ readOnlyHint: false, destructiveHint: true });
   });
 
-  it("no flags (additive write) -> { readOnlyHint: false } and no destructiveHint", () => {
+  it("no flags (additive write) -> explicit { readOnlyHint: false, destructiveHint: false }", () => {
     const a = buildAnnotations(mk({}));
-    expect(a).toEqual({ readOnlyHint: false });
-    expect(a.destructiveHint).toBeUndefined();
+    expect(a).toEqual({ readOnlyHint: false, destructiveHint: false });
+    // Not `undefined`: the MCP default for destructiveHint is true, so an
+    // omitted hint advertises an additive write as destructive.
+    expect(a.destructiveHint).toBe(false);
   });
 
   it("readOnly wins if both flags are set (defensive)", () => {
@@ -274,6 +276,7 @@ describe("tool annotation classifications", () => {
       const a = buildAnnotations(tool);
       expect(a.readOnlyHint, `${tool.name} should be readOnlyHint:true`).toBe(true);
       expect(a.destructiveHint, `${tool.name} should not be destructive`).toBeUndefined();
+      // destructiveHint is ignored by the spec when readOnlyHint is true.
     }
   });
 
@@ -318,7 +321,7 @@ describe("tool annotation classifications", () => {
     }
   });
 
-  it("additive writes are readOnlyHint:false with no destructiveHint", () => {
+  it("additive writes are readOnlyHint:false with an explicit destructiveHint:false", () => {
     const expectAdditive = [
       "drive_files_create", "drive_files_copy", "drive_files_update", "drive_permissions_create",
       "sheets_values_update", "sheets_values_append",
@@ -331,17 +334,17 @@ describe("tool annotation classifications", () => {
       const tool = byName.get(name)!;
       const a = buildAnnotations(tool);
       expect(a.readOnlyHint, name).toBe(false);
-      expect(a.destructiveHint, name).toBeUndefined();
+      expect(a.destructiveHint, name).toBe(false);
     }
   });
 
   it("gmail_threads_modify is a non-destructive write (TRASH is reversible)", () => {
     // Judgment call: this tool can apply the TRASH label, but label changes
-    // are reversible, so it stays readOnlyHint:false without destructiveHint.
+    // are reversible, so it stays readOnlyHint:false with destructiveHint:false.
     const tool = byName.get("gmail_threads_modify")!;
     const a = buildAnnotations(tool);
     expect(a.readOnlyHint).toBe(false);
-    expect(a.destructiveHint).toBeUndefined();
+    expect(a.destructiveHint).toBe(false);
   });
 
   it("completeness: every registry tool carries exactly one classification", () => {
@@ -357,11 +360,25 @@ describe("tool annotation classifications", () => {
     }
   });
 
+  it("no write tool leaves destructiveHint to the spec default of true", () => {
+    // The regression this pins: an omitted destructiveHint on a write is not
+    // neutral. The MCP schema defaults it to true, so the client shows a
+    // delete-grade prompt for tools that only create or update.
+    const writes = allTools.filter((t) => buildAnnotations(t).readOnlyHint === false);
+    expect(writes.length).toBeGreaterThan(0);
+    for (const tool of writes) {
+      expect(
+        typeof buildAnnotations(tool).destructiveHint,
+        `${tool.name} is a write and must state destructiveHint explicitly`,
+      ).toBe("boolean");
+    }
+  });
+
   it("classification counts match the intended split (16 read / 5 destructive / 16 additive)", () => {
     const read = allTools.filter((t) => buildAnnotations(t).readOnlyHint === true).length;
     const destructive = allTools.filter((t) => buildAnnotations(t).destructiveHint === true).length;
     const additive = allTools.filter(
-      (t) => buildAnnotations(t).readOnlyHint === false && !buildAnnotations(t).destructiveHint,
+      (t) => buildAnnotations(t).readOnlyHint === false && buildAnnotations(t).destructiveHint === false,
     ).length;
     expect(read).toBe(16);
     expect(destructive).toBe(5);

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,30 @@ async function main() {
   console.error(`[gws-mcp] Starting with ${tools.length} tools from services: ${services.join(", ")}`);
   console.error(`[gws-mcp] Using gws binary: ${gwsBinary}`);
 
+  const server = createServer(tools, services, gwsBinary, gwsAvailable);
+
+  // Connect via stdio
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  console.error("[gws-mcp] Server running on stdio");
+}
+
+/**
+ * Build the MCP server and register every tool on it.
+ *
+ * Split out of `main()` so tests can inspect what a client actually sees.
+ * The registry tools and the two hand-written tools are registered by
+ * different code paths, and only an assertion against the assembled server
+ * covers both — a unit test over `buildAnnotations` misses the custom ones,
+ * which is how `gmail_drafts_create` shipped without a `destructiveHint`.
+ */
+export function createServer(
+  tools: ToolDef[],
+  services: string[],
+  gwsBinary: string,
+  gwsAvailable: boolean,
+): McpServer {
   const server = new McpServer({
     name: "gws-mcp-server",
     version: "0.4.0",
@@ -363,7 +387,9 @@ async function main() {
           references: z.string().optional().describe("References header value (space-separated Message-IDs of ancestor messages)."),
         },
         // Additive write: creates a draft (never sends). Reversible, non-destructive.
-        annotations: { readOnlyHint: false },
+        // destructiveHint must be stated: the MCP default is true, and this is
+        // the tool the README leans on for "drafts are never auto-sent".
+        annotations: { readOnlyHint: false, destructiveHint: false },
       },
       async (args) => {
         try {
@@ -404,11 +430,7 @@ async function main() {
     console.error("[gws-mcp] Registered custom tool: gmail_drafts_create");
   }
 
-  // Connect via stdio
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-
-  console.error("[gws-mcp] Server running on stdio");
+  return server;
 }
 
 main().catch((err) => {

--- a/src/services.ts
+++ b/src/services.ts
@@ -30,8 +30,8 @@ export interface ToolDef {
   /**
    * Destructive write: irreversibly removes or overwrites user data (deletes).
    * Maps to MCP annotations `{ readOnlyHint: false, destructiveHint: true }`.
-   * Additive/reversible writes leave this unset (they emit `readOnlyHint: false`
-   * with no destructive hint).
+   * Additive/reversible writes leave this unset and emit an explicit
+   * `{ readOnlyHint: false, destructiveHint: false }`.
    */
   destructive?: boolean;
 }
@@ -46,11 +46,14 @@ export interface ToolAnnotationHints {
  * Map a ToolDef's declarative flags into MCP `annotations`.
  *
  * Every tool gets an explicit `readOnlyHint` (true for reads, false for any
- * write) so clients always know the side-effect class. `destructiveHint: true`
- * is added only for destructive writes (deletes). Additive/reversible writes
- * (creates, updates, label changes) carry `readOnlyHint: false` and no
- * destructive hint — the MCP default destructiveHint is true, so omitting it
- * would wrongly flag them; we leave it off intentionally to mean "non-destructive".
+ * write) so clients always know the side-effect class, and every write gets an
+ * explicit `destructiveHint`.
+ *
+ * The explicit `destructiveHint: false` matters. Per the MCP schema the hint
+ * defaults to **true**, so leaving it off an additive write does not mean
+ * "non-destructive" — it means the opposite, and the client renders a
+ * delete-grade consent prompt for a tool that only creates a draft. Only omit
+ * it on a `readOnlyHint: true` tool, where the spec says it is ignored.
  */
 export function buildAnnotations(tool: ToolDef): ToolAnnotationHints {
   if (tool.readOnly) {
@@ -60,7 +63,7 @@ export function buildAnnotations(tool: ToolDef): ToolAnnotationHints {
     return { readOnlyHint: false, destructiveHint: true };
   }
   // Write-but-additive (or reversible) tool.
-  return { readOnlyHint: false };
+  return { readOnlyHint: false, destructiveHint: false };
 }
 
 export interface ParamDef {


### PR DESCRIPTION
17 of 39 tools were advertising themselves to clients as destructive.

Per the MCP schema `destructiveHint` defaults to **true**, so omitting it on a
write means "destructive", not "neutral". The doc comment stated the default
correctly and then did the opposite with it:

> the MCP default destructiveHint is true, so omitting it would wrongly flag
> them; we leave it off intentionally to mean "non-destructive"

Every create / update / append / move was rendering a delete-grade consent
prompt. The worst case is `gmail_drafts_create` — the tool the README leans on
for its safety argument ("Drafts are never auto-sent") — asking for the same
confirmation as `drive_files_delete`. Prompts that alarming on safe operations
are how users learn to click through them.

**Fix:** emit an explicit `destructiveHint: false` for additive writes.
Annotations are hints, so this is backward compatible — it only makes them
accurate.

### The part worth reviewing

The existing tests could not have caught this, and fixing `buildAnnotations`
alone did not fix the bug. `buildAnnotations` only sees registry tools;
`drive_files_download` and `gmail_drafts_create` are hand-registered with
annotation literals. After the one-line fix, all 244 tests passed and
`gmail_drafts_create` was **still wrong** — only a `tools/list` handshake
against the built server showed it.

So this PR also extracts server construction from `main()` into an exported
`createServer()`, and adds `annotations.e2e.test.ts`, which drives a real MCP
client over the SDK's in-memory transport and asserts on the `tools/list`
payload. That covers both registration paths at the layer the client sees.

### Verification

- **254/254 pass** (was 242).
- Reverting the one-line fix **fails 10 tests**, so the assertions bite.
- On the wire, after: 39 tools, **0** writes without an explicit
  `destructiveHint`, 5 advertised destructive.

```
gmail_drafts_create: {"readOnlyHint":false,"destructiveHint":false}
drive_files_delete : {"readOnlyHint":false,"destructiveHint":true}
drive_files_list   : {"readOnlyHint":true}
```

Read-only tools keep omitting the hint, which the spec says is ignored there.

### Not in this PR

`idempotentHint` and `openWorldHint` are still absent on all 39 tools
(`gsc-mcp` emits all four). Separate change.
