### PR TITLE
Stop logging request bodies, and make SECURITY.md's claim true

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,10 @@
 # Security
 
-This server shells out to the [`gws` CLI](https://github.com/googleworkspace/cli) and never handles your Google credentials directly: authentication lives entirely in `gws auth login`. There is no token to configure here and nothing is logged beyond tool names and errors.
+This server shells out to the [`gws` CLI](https://github.com/googleworkspace/cli) and never handles your Google credentials directly: authentication lives entirely in `gws auth login`. There is no token to configure here.
 
 Things worth knowing:
 
+- **Logging stops at the subcommand.** Each call logs the `gws` subcommand it ran (`sheets spreadsheets values update`) plus any error, and never the `--params` or `--json` arguments — those carry the request body: cell values, inserted document text, grantee email addresses. MCP clients persist stderr to log files, so this is the difference between a transient value and one on disk indefinitely. Setting `GWS_MCP_DEBUG=1` logs the full command line, request bodies included; use it for debugging, not routinely. Both behaviours are pinned by tests in `src/__tests__/executor.test.ts`.
 - **Not read-only.** Tools can create, update, and delete Drive files, calendar events, sheet values, and docs, and modify Gmail thread labels. Scope what an agent can touch with `--services` (e.g. `--services calendar` exposes only calendar tools). Gmail drafts are created but never sent.
 - **Command construction is hardened.** `src/executor.ts` builds `gws` invocations without a shell where possible, validates the `--gws-path` binary path, and escapes JSON args for Windows cmd quoting. `src/mime.ts` rejects CR/LF in user-supplied header values to prevent email header injection in drafts.
 

--- a/src/__tests__/executor.test.ts
+++ b/src/__tests__/executor.test.ts
@@ -286,3 +286,68 @@ describe("executeGws", () => {
     expect(result.error).toBeUndefined();
   });
 });
+
+// ── Request bodies must not reach the logs ──────────────────────────────
+// SECURITY.md: "nothing is logged beyond tool names and errors." That was a
+// prose promise with no mechanism; executeGws logged the full command line,
+// including --params and --json. MCP clients persist stderr to disk.
+
+describe("executeGws logging", () => {
+  const sheetsUpdate: ToolDef = {
+    name: "sheets_values_update",
+    description: "test",
+    command: ["sheets", "spreadsheets", "values", "update"],
+    params: [{ name: "spreadsheetId", description: "id", type: "string", required: true }],
+    bodyParams: [{ name: "values", description: "values", type: "string", required: false }],
+  };
+
+  const SECRET_ID = "SHEET_ID_THAT_MUST_NOT_BE_LOGGED";
+  const SECRET_BODY = "555-01-9999";
+
+  async function runAndCaptureLogs(): Promise<string> {
+    const proc = makeFakeProc();
+    vi.mocked(spawn).mockReturnValue(proc as unknown as ReturnType<typeof spawn>);
+    const lines: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+      lines.push(a.map(String).join(" "));
+    });
+    try {
+      const p = executeGws(
+        sheetsUpdate,
+        { spreadsheetId: SECRET_ID, values: SECRET_BODY },
+        "gws",
+      );
+      proc.stdout.emit("data", Buffer.from("{}"));
+      proc.emit("close", 0);
+      await p;
+      return lines.join("\n");
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  it("logs the subcommand but neither the params nor the request body", async () => {
+    delete process.env.GWS_MCP_DEBUG;
+    const logged = await runAndCaptureLogs();
+
+    // The operation is still identifiable...
+    expect(logged).toContain("sheets spreadsheets values update");
+    // ...but the caller's data is not in it.
+    expect(logged).not.toContain(SECRET_ID);
+    expect(logged).not.toContain(SECRET_BODY);
+    expect(logged).not.toContain("--params");
+    expect(logged).not.toContain("--json");
+  });
+
+  it("logs the full command line when GWS_MCP_DEBUG is set", async () => {
+    // Asserted so the test above cannot pass merely because nothing is logged.
+    process.env.GWS_MCP_DEBUG = "1";
+    try {
+      const logged = await runAndCaptureLogs();
+      expect(logged).toContain(SECRET_ID);
+      expect(logged).toContain("--json");
+    } finally {
+      delete process.env.GWS_MCP_DEBUG;
+    }
+  });
+});

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -186,7 +186,16 @@ export async function executeGws(
 ): Promise<ExecResult> {
   const cliArgs = buildArgs(tool, args);
 
-  console.error(`[gws-mcp] Executing: ${gwsBinary} ${cliArgs.join(" ")}`);
+  // Log the subcommand only. cliArgs carries --params and --json, which hold
+  // the full request body: spreadsheet cell values, inserted document text,
+  // grantee email addresses, calendar event details. MCP clients persist
+  // stderr to log files, so anything printed here lands on disk indefinitely.
+  // SECURITY.md promises nothing is logged beyond tool names and errors.
+  if (process.env.GWS_MCP_DEBUG) {
+    console.error(`[gws-mcp] Executing: ${gwsBinary} ${cliArgs.join(" ")}`);
+  } else {
+    console.error(`[gws-mcp] Executing: ${gwsBinary} ${tool.command.join(" ")}`);
+  }
 
   try {
     const { stdout, stderr } = await spawnGwsRaw(gwsBinary, cliArgs);


### PR DESCRIPTION
SECURITY.md says:

> nothing is logged beyond tool names and errors

That was a prose promise with no mechanism. `executor.ts` logged the full
command line, and the command line carries `--params` and `--json`:

```
[gws-mcp] Executing: gws sheets spreadsheets values update
  --params "{\"spreadsheetId\":\"...\"}"
  --json "{\"values\":[[\"salary\",\"185000\"],[\"ssn\",\"555-01-9999\"]]}"
```

So every declarative tool's full request body went to stderr — spreadsheet cell
values, inserted document text (`docs_batchUpdate` sends the whole document),
grantee email addresses (`drive_permissions_create`), calendar event details.
MCP clients persist stderr to log files, which is the difference between a
transient value and one sitting on disk indefinitely.

The log line now names the subcommand only, so calls stay identifiable:

```
[gws-mcp] Executing: gws sheets spreadsheets values update
```

`GWS_MCP_DEBUG=1` restores the full command line for debugging.

### Tests

Two, and the second exists to keep the first honest:

1. The request body and params are **absent** from captured stderr.
2. They **are** present under `GWS_MCP_DEBUG` — so test 1 cannot pass merely
   because nothing was logged at all.

Restoring the old line fails test 1. Verified: **251/251 pass**.

SECURITY.md now describes what the code does, names the debug escape hatch, and
points at the tests that enforce it.

### One thing I left alone

`gmail_drafts_create` goes through `spawnGwsRaw` directly and was never routed
through this log line, so the most sensitive payload in the server happened to
be exempt already. Unchanged here.
