### PR TITLE
docs: correct the scope-picker claim and the service count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ MCP server that exposes Google Workspace CLI (gws) as Model Context Protocol too
 
 ## Architecture
 - `src/index.ts` — MCP server bootstrap, Zod schema generation, tool registration. Also hosts custom tools that don't fit the declarative ToolDef pattern (`drive_files_download`, `gmail_drafts_create`).
-- `src/services.ts` — Declarative tool definitions across 5 services (drive, sheets, calendar, docs, gmail). Each entry maps to a `gws` CLI command + params/body.
+- `src/services.ts` — Declarative tool definitions across 6 services (drive, sheets, calendar, docs, gmail, tasks). Each entry maps to a `gws` CLI command + params/body.
 - `src/executor.ts` — Command builder and runner with security hardening (shell injection prevention, path validation).
 - `src/mime.ts` — RFC 2822 builder + base64url encoding for `gmail_drafts_create`. Includes CRLF-injection guard on header values.
 - `src/__tests__/` — Vitest unit tests, one file per source module.

--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ The `gws` CLI had a built-in MCP server that was [removed in v0.8.0](https://git
 
 This server exposes **no send tool** — the closest thing is `gmail_drafts_create`, which explicitly does not send. The token `gws auth login` mints is broader than that.
 
-`gws auth login` opens a scope picker listing **nine** scopes, **seven** of them pre-selected: full read-write `drive`, `spreadsheets`, `gmail.modify` (Google documents it as "Read, compose, and send emails"), `calendar`, `documents`, `presentations`, and `tasks`. Pressing Enter accepts those seven. Run non-interactively and you get the same seven as `DEFAULT_SCOPES`.
+`gws auth login` opens a scope picker listing **nine** scopes. The default grant is **seven**: full read-write `drive`, `spreadsheets`, `gmail.modify` (Google documents it as "Read, compose, and send emails"), `calendar`, `documents`, `presentations`, and `tasks` — the same seven you get running non-interactively as `DEFAULT_SCOPES`.
 
-The other two rows are Cloud Pub/Sub and Cloud Platform, and neither is part of the default grant — `gws auth login --help` describes `--full` as "Request all scopes incl. pubsub + cloud-platform."
+The other two rows are Cloud Pub/Sub and Cloud Platform, and neither is part of the default grant — `gws auth login --help` describes `--full` as "Request all scopes incl. pubsub + cloud-platform."
+
+Which rows start *checked* has not been verified against a live picker — the seven above are the documented default grant, not an observation of the TUI. Read the checkboxes before pressing Enter rather than trusting this paragraph.
 
 So the token on disk can send mail and rewrite Drive even though nothing here will. **Deselect what you do not need in the picker**, or:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ The `gws` CLI had a built-in MCP server that was [removed in v0.8.0](https://git
 
 This server exposes **no send tool** — the closest thing is `gmail_drafts_create`, which explicitly does not send. The token `gws auth login` mints is broader than that.
 
-`gws auth login` opens a scope picker with **nine** scopes pre-selected, including `gmail.modify` (Google documents it as "Read, compose, and send emails"), full read-write `drive`, and `cloud-platform`. Pressing Enter accepts all of them. Run non-interactively and you get `DEFAULT_SCOPES`, which is the same list minus the picker.
+`gws auth login` opens a scope picker listing **nine** scopes, **seven** of them pre-selected: full read-write `drive`, `spreadsheets`, `gmail.modify` (Google documents it as "Read, compose, and send emails"), `calendar`, `documents`, `presentations`, and `tasks`. Pressing Enter accepts those seven. Run non-interactively and you get the same seven as `DEFAULT_SCOPES`.
+
+The other two rows are Cloud Pub/Sub and Cloud Platform, and neither is part of the default grant — `gws auth login --help` describes `--full` as "Request all scopes incl. pubsub + cloud-platform."
 
 So the token on disk can send mail and rewrite Drive even though nothing here will. **Deselect what you do not need in the picker**, or:
 
@@ -38,7 +40,7 @@ So the token on disk can send mail and rewrite Drive even though nothing here wi
 gws auth login --readonly    # read-only across services
 ```
 
-One trap worth knowing: `-s gmail` does **not** narrow the picker to Gmail alone. `cloud-platform` is treated as a cross-service scope and is always included, pre-selected — deselect it manually if you use that flag.
+`-s gmail` limits the picker to Gmail, per the flag's own help text ("Comma-separated service names to limit scope picker"). It cannot pull in `cloud-platform` or `pubsub`, because those two are reachable only through `--full`.
 
 **On Linux there is no keyring, and the encryption key is a file next to the data it encrypts.** `gws` enables the `keyring` crate's native backends only for macOS and Windows; on every other platform the dependency is declared with no backend feature, so the store falls through to writing `.encryption_key` into `~/.config/gws/`. That file is not a backup of a key held elsewhere — it is the key, and the credential store's own doc comment says it is never deleted. Setting `GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND=file` changes nothing there because that is already the only path. On macOS and Windows the key file is removed once the OS keyring holds the key. **If you run this headless on Linux, treat `~/.config/gws/` as a password file: anyone who can read the directory has the credentials.**
 


### PR DESCRIPTION
Closes two items from the P2/P3 tail in conorbronsdon/personal-context#147.

## 1. README `cloud-platform` claim — the claim was wrong

README:33 said the picker pre-selects nine scopes "including `cloud-platform`", and README:41 said `cloud-platform` "is always included, pre-selected" even under `-s`. Issue #147 flagged this as *not fully confirmed* because nobody had run the picker. I still have not run it — it touches real Google credentials — but everything reachable without it now agrees, and it agrees against the corrected version.

**Evidence, all from `@googleworkspace/cli@0.22.5` installed into a scratch dir (never authenticated):**

`gws auth login --help`:

```
Options:
      --readonly             Request read-only scopes
      --full                 Request all scopes incl. pubsub + cloud-platform
      --scopes <scopes>      Comma-separated custom scopes
  -s, --services <services>  Comma-separated service names to limit scope picker (e.g. drive,gmail,sheets)
```

`--full` is documented as adding pubsub + cloud-platform, so neither can be in the default set.

The default scope array, contiguous in the Mach-O binary's string table — **seven** entries:

```
https://www.googleapis.com/auth/drive
https://www.googleapis.com/auth/spreadsheets
https://www.googleapis.com/auth/gmail.modify
https://www.googleapis.com/auth/calendar
https://www.googleapis.com/auth/documents
https://www.googleapis.com/auth/presentations
https://www.googleapis.com/auth/tasks
```

The picker's label table, also contiguous, which is where "nine" came from — seven service rows plus two:

```
Google Drive  Google Sheets  Gmail  Google Calendar  Google Docs  Google Slides  Google Tasks
https://www.googleapis.com/auth/pubsub  Cloud Pub/Sub  Cloud Platform
Select OAuth scopes
Space to toggle, 'a' to select all, Enter to confirm
```

Nine rows listed, seven pre-selected. The old text read the row count as the pre-selected count.

The fourth source is the one from the issue: the live token carries ten scopes — those seven plus `openid`, `userinfo.email`, `userinfo.profile` — with no `cloud-platform` and no `pubsub`. The binary's `auth status` scope table lists exactly that set, no cloud-platform in it.

**What is still unverified and what would settle it:** the picker's initial *checkbox* state. Four independent sources imply seven-of-nine pre-selected, but none of them is the picker. Settling it means running `gws auth login` interactively and reading the checkboxes before pressing anything — a real OAuth flow against a real Google account. Not something I should run. The PR does not claim the picker was observed.

## 2. `CLAUDE.md:7` service count — confirmed, fixed

Said "5 services (drive, sheets, calendar, docs, gmail)". `tasks` was missing:

```
$ node -e 'import("./build/services.js").then(s => { ... })'
ALL_SERVICES: drive, sheets, calendar, docs, gmail, tasks count: 6
registry tools: 37
   drive 8
   sheets 4
   calendar 5
   docs 3
   gmail 5
   tasks 12
```

## Verification

Full CI-equivalent on this branch:

```
$ npm run lint     # tsc --noEmit
(clean)
$ npm run build    # tsc
(clean)
$ npm test
 Test Files  12 passed (12)
      Tests  258 passed (258)
$ npm audit --audit-level=high
found 0 vulnerabilities
```

Docs-only change, so the test count is unchanged from `main` at 258.

One note on the diff: `README.md` uses CRLF and contains 16 pre-existing `\r\r\n` lines. My first pass normalized them and produced 34 changed lines of pure churn; I rebuilt the file byte-wise to preserve them, so the diff is now the 4 lines I actually meant to change.

## Not included here

The two workflow-file corrections from #147 (`ci.yml`'s `--audit-level` gate, `publish.yml`'s "can never drift again" comment) are held back — the local `gh` token has scopes `gist, read:org, repo` and no `workflow`, so GitHub rejects any push touching `.github/workflows/`. They need `gh auth refresh -s workflow` (interactive) or Conor applying them directly. Details in the report.