### PR TITLE
Report the real version and the real tool count, and stop shipping tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node build/index.js",
-    "lint": "tsc --noEmit",
+    "lint": "tsc --noEmit -p tsconfig.lint.json",
     "test": "vitest run"
   },
   "files": [

--- a/src/__tests__/annotations.e2e.test.ts
+++ b/src/__tests__/annotations.e2e.test.ts
@@ -11,10 +11,26 @@
  */
 
 import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { createServer } from "../index.js";
+import { createServer, countRegisteredTools, SERVER_VERSION } from "../index.js";
 import { getToolsForServices, ALL_SERVICES } from "../services.js";
+
+/** Drive a real MCP client against an assembled server and return it. */
+async function connect(services: string[]): Promise<Client> {
+  const server = createServer(
+    getToolsForServices(services),
+    services,
+    "gws",
+    // gwsAvailable: nothing is executed here, only metadata is read.
+    false,
+  );
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "annotations-test", version: "1.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
 
 type ListedTool = {
   name: string;
@@ -24,16 +40,7 @@ type ListedTool = {
 let tools: ListedTool[];
 
 beforeAll(async () => {
-  const server = createServer(
-    getToolsForServices(ALL_SERVICES),
-    ALL_SERVICES,
-    "gws",
-    // gwsAvailable: nothing is executed here, only the tool list is read.
-    false,
-  );
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  const client = new Client({ name: "annotations-test", version: "1.0.0" });
-  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  const client = await connect(ALL_SERVICES);
   tools = (await client.listTools()).tools as ListedTool[];
 });
 
@@ -73,6 +80,24 @@ describe("advertised annotations", () => {
     expect(byName("drive_files_download").annotations?.readOnlyHint).toBe(true);
   });
 
+  it("reports the version from package.json, not a hardcoded literal", async () => {
+    // `version` in index.ts was pinned at "0.4.0" while the publish workflow
+    // derived server.json from package.json, so the next bump would have
+    // shipped a stale version to every client. Compare against package.json
+    // read here rather than against SERVER_VERSION, which would only prove the
+    // constant equals itself.
+    const pkg = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf-8"),
+    ) as { version: string };
+
+    const client = await connect(ALL_SERVICES);
+    const advertised = client.getServerVersion();
+
+    expect(advertised?.name).toBe("gws-mcp-server");
+    expect(advertised?.version).toBe(pkg.version);
+    expect(SERVER_VERSION).toBe(pkg.version);
+  });
+
   it("only irreversible removals are advertised as destructive", () => {
     // tasks_tasks_clear is in this list and is not a *_delete: it permanently
     // removes completed tasks from a list, so it belongs here.
@@ -87,5 +112,38 @@ describe("advertised annotations", () => {
       "tasks_tasks_clear",
       "tasks_tasks_delete",
     ]);
+  });
+});
+
+describe("startup tool count", () => {
+  // The startup log read `tools.length` from the registry, which is taken
+  // before the two hand-registered tools are added — it said 37 while a client
+  // saw 39. `countRegisteredTools` restates createServer's registration guards,
+  // so it is only trustworthy if checked against a real tools/list. Subsets
+  // matter: the custom tools are gated on drive and gmail individually.
+  const cases: string[][] = [
+    ALL_SERVICES,
+    ["drive"],
+    ["gmail"],
+    ["drive", "gmail"],
+    ["sheets"],
+    ["calendar", "docs", "tasks"],
+  ];
+
+  for (const services of cases) {
+    it(`matches what a client lists for --services ${services.join(",")}`, async () => {
+      const client = await connect(services);
+      const listed = (await client.listTools()).tools;
+      expect(countRegisteredTools(getToolsForServices(services), services)).toBe(listed.length);
+    });
+  }
+
+  it("counts the custom tools that the registry does not", () => {
+    // Guards against the fix being "fudge the string": the number has to come
+    // from somewhere other than the registry length.
+    const registry = getToolsForServices(ALL_SERVICES);
+    expect(registry.length).toBe(37);
+    expect(countRegisteredTools(registry, ALL_SERVICES)).toBe(39);
+    expect(countRegisteredTools(registry, ["sheets"])).toBe(registry.length);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,23 @@ import { getToolsForServices, ALL_SERVICES, buildAnnotations, type ToolDef } fro
 import { executeGws, spawnGwsRaw, escapeJsonArg } from "./executor.js";
 import { buildRfc2822, base64url } from "./mime.js";
 
+// ── Package metadata ───────────────────────────────────────────────────
+
+/**
+ * The version advertised to MCP clients, read from package.json at runtime.
+ *
+ * Read rather than imported. `import pkg from "../package.json"` needs
+ * `resolveJsonModule`, and package.json sits outside `rootDir: ./src` — tsc
+ * would widen the output root to include it and emit `build/src/index.js`,
+ * breaking the `bin` path in package.json. Resolving from `import.meta.url`
+ * keeps the emit layout intact and works in both trees: `src/../package.json`
+ * when running from source, `build/../package.json` once installed, since npm
+ * always ships package.json at the tarball root.
+ */
+export const SERVER_VERSION: string = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+).version;
+
 // ── CLI argument parsing ───────────────────────────────────────────────
 
 function parseArgs(): { services: string[]; gwsBinary: string } {
@@ -129,6 +146,33 @@ export function buildZodSchema(tool: ToolDef): Record<string, z.ZodTypeAny> {
   return shape;
 }
 
+// ── Tool counting ──────────────────────────────────────────────────────
+
+/**
+ * The tools `createServer` registers by hand, and the service that gates each.
+ *
+ * These are not in the `services.ts` registry, so `getToolsForServices()` does
+ * not count them. `main()` logged `tools.length` before the server was built
+ * and reported 37 while a client listing tools saw 39.
+ */
+export const CUSTOM_TOOLS: ReadonlyArray<{ name: string; service: string }> = [
+  { name: "drive_files_download", service: "drive" },
+  { name: "gmail_drafts_create", service: "gmail" },
+];
+
+/**
+ * How many tools a client will actually see: registry tools plus whichever
+ * custom tools have their gating service enabled.
+ *
+ * This still restates the guards inside `createServer` rather than driving
+ * them, so the binding constraint is the e2e test that compares this against a
+ * real `tools/list` for several service subsets. A count derived from the same
+ * data it is meant to check would agree with itself and prove nothing.
+ */
+export function countRegisteredTools(tools: ToolDef[], services: string[]): number {
+  return tools.length + CUSTOM_TOOLS.filter((t) => services.includes(t.service)).length;
+}
+
 // ── Temp file helper ───────────────────────────────────────────────────
 
 /**
@@ -158,7 +202,9 @@ async function main() {
     process.exit(1);
   }
 
-  console.error(`[gws-mcp] Starting with ${tools.length} tools from services: ${services.join(", ")}`);
+  console.error(
+    `[gws-mcp] Starting with ${countRegisteredTools(tools, services)} tools from services: ${services.join(", ")}`,
+  );
   console.error(`[gws-mcp] Using gws binary: ${gwsBinary}`);
 
   const server = createServer(tools, services, gwsBinary, gwsAvailable);
@@ -187,7 +233,7 @@ export function createServer(
 ): McpServer {
   const server = new McpServer({
     name: "gws-mcp-server",
-    version: "0.4.0",
+    version: SERVER_VERSION,
   });
 
   // Register each tool, attaching MCP annotations derived from the ToolDef's

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,8 @@
     "sourceMap": false
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "build"]
+  // Tests are excluded from the *emit* only — they were compiling to
+  // build/__tests__ and shipping in the npm tarball. Type-checking still
+  // covers them via tsconfig.lint.json, which `npm run lint` uses.
+  "exclude": ["node_modules", "build", "src/__tests__"]
 }

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,0 +1,14 @@
+{
+  // Type-check everything under src/, tests included.
+  //
+  // tsconfig.json excludes src/__tests__ so the tests stay out of build/ and
+  // out of the npm tarball. That exclusion must not cost us type-checking on
+  // them, so `npm run lint` points here instead: same compiler options, tests
+  // back in scope, nothing emitted.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "build"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Never collect from build/. Until now tests compiled to build/__tests__,
+    // and because `npm run build` runs before `npm test` both in CI and in
+    // CLAUDE.md's documented loop, vitest picked up the .ts source *and* the
+    // compiled .js copy and ran all 129 tests twice — main reported "258
+    // passed" for 129 distinct tests. The tsconfig change stops the emit, so a
+    // fresh checkout would be fine, but a stale build/ in an existing
+    // working tree would still double-count. This makes it structural.
+    exclude: ["**/node_modules/**", "build/**"],
+  },
+});


### PR DESCRIPTION
The P2 version item and three P3 build items from conorbronsdon/personal-context#147. All four confirmed against the tree first.

## 1. Hardcoded server version (P2) — confirmed, fixed

`src/index.ts` pinned `version: "0.4.0"` in the `McpServer` constructor. In sync today, but `publish.yml` derives `server.json` from `package.json` and never touches `index.ts`, so the next bump ships a stale version to clients.

`import pkg from "../package.json"` is the trap here. It needs `resolveJsonModule`, and `package.json` sits outside `rootDir: ./src` — tsc widens the output root to cover it and emits `build/src/index.js`, which breaks the `"bin": "./build/index.js"` path. Resolving from `import.meta.url` instead keeps the emit layout: `src/../package.json` from source, `build/../package.json` once installed, and npm always ships `package.json` at the tarball root.

**Verified against a real installed tarball, not the dev tree** — this is the part that only works or doesn't at runtime:

```
$ npm pack --pack-destination /tmp/installtest
$ cd /tmp/installtest && npm install ./gws-mcp-server-0.4.0.tgz
$ ./node_modules/.bin/gws-mcp-server --services sheets
[gws-mcp] Starting with 4 tools from services: sheets
[gws-mcp] Server running on stdio

$ node -e '... import installed build/index.js ...'
SERVER_VERSION from installed tarball: 0.4.0

# then edit the *installed* package.json to 9.9.9 and re-import:
after bumping package.json to 9.9.9, server reports: 9.9.9
```

The e2e test asserts it through a real handshake — `client.getServerVersion()` after `initialize`, compared against `package.json` read independently rather than against `SERVER_VERSION` (which would only prove the constant equals itself).

## 2. Startup tool count (P3) — confirmed, fixed

Logged `tools.length` from the registry, taken before the two hand-registered tools are added.

Before / after, from the built output:

```
# before
[gws-mcp] Starting with 37 tools from services: drive, sheets, calendar, docs, gmail, tasks

# after
[gws-mcp] Starting with 39 tools from services: drive, sheets, calendar, docs, gmail, tasks
[gws-mcp] Starting with 9 tools from services: drive        # README: drive (9 tools)
[gws-mcp] Starting with 4 tools from services: sheets       # README: sheets (4 tools)
```

Not a fudged string: `countRegisteredTools()` adds the custom tools whose gating service is enabled. It restates `createServer`'s guards rather than driving them, so it is only trustworthy if something independent checks it — the e2e test compares it against a real `tools/list` for six service subsets, including `["drive"]` and `["gmail"]` separately since the two custom tools are gated individually.

## 3. Compiled tests in the npm tarball (P3) — confirmed, fixed

`npm pack --dry-run`:

| | before | after |
|---|---|---|
| total files | 25 | **13** |
| package size | 38.3 kB | **27.0 kB** |
| unpacked size | 153.9 kB | **96.7 kB** |

All six `build/__tests__/*.js` plus their `.d.ts` are gone; the installed package's `build/` is now just the five modules and their declarations.

Type-checking on the tests is **not** lost. `tsconfig.json` excludes `src/__tests__` from the emit only; `npm run lint` now points at a new `tsconfig.lint.json` that puts them back in scope with `noEmit`.

## The thing I did not expect: `main` was not running 258 tests

Tests compiled to `build/__tests__`, and `npm run build` runs before `npm test` in CI and in CLAUDE.md's loop. So vitest collected the `.ts` source **and** the compiled `.js` copy and ran every test twice:

```
$ npx vitest run --reporter=json   # on main
build/__tests__/annotations.e2e.test.js
build/__tests__/errors.test.js
... (6 compiled)
src/__tests__/annotations.e2e.test.ts
src/__tests__/errors.test.ts
... (6 source)
Test Files  12 passed (12)
     Tests  258 passed (258)
```

129 distinct tests, reported as 258. Excluding tests from the emit fixes it as a side effect, so **the count on this branch drops to 137, and that is not a regression** — it is 129 real tests plus the 8 added here. `vitest.config.ts` now excludes `build/**` so a stale build directory in an existing working tree can't bring the double-count back.

## Verification

Full CI-equivalent, clean `build/`:

```
$ rm -rf build
$ npm run lint      # tsc --noEmit -p tsconfig.lint.json
(clean)
$ npm run build     # tsc
(clean)
$ ls build/
errors.d.ts errors.js executor.d.ts executor.js index.d.ts index.js
mime.d.ts mime.js services.d.ts services.js          # no __tests__
$ npm test
 Test Files  6 passed (6)
      Tests  137 passed (137)
$ npm audit --audit-level=high
found 0 vulnerabilities
```

New tests: 1 version-through-handshake, 6 tool-count subsets, 1 asserting `countRegisteredTools` differs from the bare registry length (37 vs 39) so a fudge can't pass.