### PR TITLE
Add --read-only, registering only the 17 read-only tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ npm install && npm run build
 |------|-------------|---------|
 | `--services, -s` | Comma-separated list of services to expose | All services |
 | `--gws-path` | Path to the `gws` binary | `gws` |
+| `--read-only` | Register only the read-only tools | off |
+
+### `--read-only`
+
+`--read-only` registers **17 tools** instead of 39. Every tool that writes to Google is left unregistered, so it never appears in `tools/list` and there is nothing for an agent to call — including `gmail_drafts_create`, which is a write even though it never sends. `drive_files_download` stays, since it reads.
+
+```bash
+gws-mcp-server --read-only
+gws-mcp-server --read-only --services drive,calendar   # combines with -s
+```
+
+This constrains the **agent, not the credential**. The token on disk keeps whatever scopes it was granted, and anything else on the machine can still use it. `gws auth login --readonly` is what narrows the token; the two are complementary. For an MCP server the agent is the threat model, but that is the limit of the claim.
 
 ## Available services & tools
 

--- a/src/__tests__/annotations.e2e.test.ts
+++ b/src/__tests__/annotations.e2e.test.ts
@@ -18,13 +18,14 @@ import { createServer, countRegisteredTools, SERVER_VERSION } from "../index.js"
 import { getToolsForServices, ALL_SERVICES } from "../services.js";
 
 /** Drive a real MCP client against an assembled server and return it. */
-async function connect(services: string[]): Promise<Client> {
+async function connect(services: string[], readOnly = false): Promise<Client> {
   const server = createServer(
     getToolsForServices(services),
     services,
     "gws",
     // gwsAvailable: nothing is executed here, only metadata is read.
     false,
+    readOnly,
   );
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const client = new Client({ name: "annotations-test", version: "1.0.0" });
@@ -145,5 +146,65 @@ describe("startup tool count", () => {
     expect(registry.length).toBe(37);
     expect(countRegisteredTools(registry, ALL_SERVICES)).toBe(39);
     expect(countRegisteredTools(registry, ["sheets"])).toBe(registry.length);
+  });
+});
+
+describe("--read-only", () => {
+  // The flag's whole value is that it is enforced at the server boundary
+  // instead of in prose, so every assertion here goes through a real
+  // tools/list. A unit test over selectTools would miss gmail_drafts_create,
+  // which is registered by hand — the same blind spot that let it ship
+  // advertising itself as destructive.
+  let roTools: ListedTool[];
+
+  beforeAll(async () => {
+    const client = await connect(ALL_SERVICES, true);
+    roTools = (await client.listTools()).tools as ListedTool[];
+  });
+
+  it("exposes exactly the 17 read-only tools", () => {
+    expect(roTools.length).toBe(17);
+    expect(countRegisteredTools(getToolsForServices(ALL_SERVICES), ALL_SERVICES, true)).toBe(17);
+  });
+
+  it("lists no tool that advertises itself as a write", () => {
+    const writes = roTools.filter((t) => t.annotations?.readOnlyHint !== true).map((t) => t.name);
+    expect(writes).toEqual([]);
+  });
+
+  it("drops every write the default server exposes", () => {
+    const dropped = tools
+      .filter((t) => t.annotations?.readOnlyHint !== true)
+      .map((t) => t.name);
+    // 39 default - 17 read-only = 22 writes, all gone.
+    expect(dropped.length).toBe(22);
+    for (const name of dropped) {
+      expect(roTools.find((t) => t.name === name)).toBeUndefined();
+    }
+  });
+
+  it("drops the hand-registered write and keeps the hand-registered read", () => {
+    // gmail_drafts_create bypasses the registry filter entirely.
+    expect(roTools.find((t) => t.name === "gmail_drafts_create")).toBeUndefined();
+    expect(roTools.find((t) => t.name === "drive_files_download")).toBeDefined();
+  });
+
+  it("keeps no destructive tool", () => {
+    expect(roTools.filter((t) => t.annotations?.destructiveHint === true)).toEqual([]);
+  });
+
+  it("is additive — the default server is unchanged", () => {
+    expect(tools.length).toBe(39);
+    expect(tools.find((t) => t.name === "gmail_drafts_create")).toBeDefined();
+    expect(tools.find((t) => t.name === "drive_files_delete")).toBeDefined();
+  });
+
+  it("narrows per service, and the count still matches a real tools/list", async () => {
+    for (const services of [["drive"], ["gmail"], ["sheets"], ["calendar", "tasks"]]) {
+      const client = await connect(services, true);
+      const listed = (await client.listTools()).tools;
+      expect(countRegisteredTools(getToolsForServices(services), services, true)).toBe(listed.length);
+      expect(listed.every((t) => (t.annotations as ListedTool["annotations"])?.readOnlyHint === true)).toBe(true);
+    }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,13 +49,16 @@ export const SERVER_VERSION: string = JSON.parse(
 
 // ── CLI argument parsing ───────────────────────────────────────────────
 
-function parseArgs(): { services: string[]; gwsBinary: string } {
+function parseArgs(): { services: string[]; gwsBinary: string; readOnly: boolean } {
   const args = process.argv.slice(2);
   let services = ALL_SERVICES;
   let gwsBinary = "gws";
+  let readOnly = false;
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--services" || args[i] === "-s") {
+    if (args[i] === "--read-only") {
+      readOnly = true;
+    } else if (args[i] === "--services" || args[i] === "-s") {
       const val = args[++i];
       if (val) {
         const requested = val.split(",").map((s) => s.trim().toLowerCase());
@@ -76,16 +79,19 @@ OPTIONS:
   --services, -s <list>   Comma-separated services to expose (default: all)
                           Available: ${ALL_SERVICES.join(", ")}
   --gws-path <path>       Path to gws binary (default: "gws")
+  --read-only             Register only the read-only tools. No tool that
+                          writes to Google is exposed at all.
   --help, -h              Show this help
 
 EXAMPLE:
   gws-mcp-server --services drive,sheets,calendar
+  gws-mcp-server --read-only
 `);
       process.exit(0);
     }
   }
 
-  return { services, gwsBinary };
+  return { services, gwsBinary, readOnly };
 }
 
 /**
@@ -155,9 +161,11 @@ export function buildZodSchema(tool: ToolDef): Record<string, z.ZodTypeAny> {
  * not count them. `main()` logged `tools.length` before the server was built
  * and reported 37 while a client listing tools saw 39.
  */
-export const CUSTOM_TOOLS: ReadonlyArray<{ name: string; service: string }> = [
-  { name: "drive_files_download", service: "drive" },
-  { name: "gmail_drafts_create", service: "gmail" },
+export const CUSTOM_TOOLS: ReadonlyArray<{ name: string; service: string; readOnly: boolean }> = [
+  // drive_files_download reads Drive; savePath writes a local file, not Drive.
+  { name: "drive_files_download", service: "drive", readOnly: true },
+  // gmail_drafts_create is a write even though it never sends.
+  { name: "gmail_drafts_create", service: "gmail", readOnly: false },
 ];
 
 /**
@@ -169,8 +177,24 @@ export const CUSTOM_TOOLS: ReadonlyArray<{ name: string; service: string }> = [
  * real `tools/list` for several service subsets. A count derived from the same
  * data it is meant to check would agree with itself and prove nothing.
  */
-export function countRegisteredTools(tools: ToolDef[], services: string[]): number {
-  return tools.length + CUSTOM_TOOLS.filter((t) => services.includes(t.service)).length;
+export function countRegisteredTools(tools: ToolDef[], services: string[], readOnly = false): number {
+  return (
+    selectTools(tools, readOnly).length +
+    CUSTOM_TOOLS.filter((t) => services.includes(t.service) && (!readOnly || t.readOnly)).length
+  );
+}
+
+/**
+ * The registry tools to register, narrowed to reads under `--read-only`.
+ *
+ * Enforced here, at the server boundary, rather than in the README's prose:
+ * under `--read-only` a write tool is never registered, so it is not in
+ * `tools/list` and there is nothing for a client to call. This constrains the
+ * agent, not the credential — the token on disk can still write. For an MCP
+ * server the agent is the threat model, but that is the limit of the claim.
+ */
+export function selectTools(tools: ToolDef[], readOnly: boolean): ToolDef[] {
+  return readOnly ? tools.filter((t) => t.readOnly === true) : tools;
 }
 
 // ── Temp file helper ───────────────────────────────────────────────────
@@ -191,23 +215,23 @@ export function makeTmpFileName(prefix: string): string {
 // ── Main ───────────────────────────────────────────────────────────────
 
 async function main() {
-  const { services, gwsBinary } = parseArgs();
+  const { services, gwsBinary, readOnly } = parseArgs();
 
   const gwsAvailable = validateGwsBinary(gwsBinary);
 
   const tools = getToolsForServices(services);
 
-  if (tools.length === 0) {
+  if (countRegisteredTools(tools, services, readOnly) === 0) {
     console.error("[gws-mcp] FATAL: No tools registered. Check --services flag.");
     process.exit(1);
   }
 
   console.error(
-    `[gws-mcp] Starting with ${countRegisteredTools(tools, services)} tools from services: ${services.join(", ")}`,
+    `[gws-mcp] Starting with ${countRegisteredTools(tools, services, readOnly)} tools from services: ${services.join(", ")}${readOnly ? " (read-only)" : ""}`,
   );
   console.error(`[gws-mcp] Using gws binary: ${gwsBinary}`);
 
-  const server = createServer(tools, services, gwsBinary, gwsAvailable);
+  const server = createServer(tools, services, gwsBinary, gwsAvailable, readOnly);
 
   // Connect via stdio
   const transport = new StdioServerTransport();
@@ -230,11 +254,15 @@ export function createServer(
   services: string[],
   gwsBinary: string,
   gwsAvailable: boolean,
+  readOnly = false,
 ): McpServer {
   const server = new McpServer({
     name: "gws-mcp-server",
     version: SERVER_VERSION,
   });
+
+  // Under --read-only nothing that writes is registered at all.
+  tools = selectTools(tools, readOnly);
 
   // Register each tool, attaching MCP annotations derived from the ToolDef's
   // declarative readOnly/destructive flags so clients can reason about side
@@ -416,7 +444,9 @@ export function createServer(
   // Creates a Gmail draft. The standard ToolDef pattern can't express the
   // Draft body (a base64url-encoded RFC 2822 message wrapped in
   // {message: {raw, threadId}}), so this is registered separately.
-  if (services.includes("gmail")) {
+  // Skipped under --read-only: creating a draft is a write, even though it
+  // never sends. drive_files_download below has no such guard — it reads.
+  if (services.includes("gmail") && !readOnly) {
     server.registerTool(
       "gmail_drafts_create",
       {


### PR DESCRIPTION
The `--read-only` feature from conorbronsdon/personal-context#147. It stayed small and additive, so I shipped it.

> **Stacked on #27.** Base is `fix/version-toolcount-tarball`, not `main` — `--read-only` has to feed `countRegisteredTools()` from that PR or the startup log lies again. Merge #27 first, then this retargets to `main` on its own. Please don't squash-merge #27 with `--delete-branch` while this is open.

## What it does

39 tools → 17. Enforced at the server boundary rather than in prose: a write tool is never registered under the flag, so it is absent from `tools/list` and there is nothing for a client to call.

```
$ node build/index.js --read-only
[gws-mcp] Starting with 17 tools from services: drive, sheets, calendar, docs, gmail, tasks (read-only)
[gws-mcp] Registered custom tool: drive_files_download

$ node build/index.js
[gws-mcp] Starting with 39 tools from services: drive, sheets, calendar, docs, gmail, tasks

$ node build/index.js --read-only --services drive
[gws-mcp] Starting with 4 tools from services: drive (read-only)
[gws-mcp] Registered custom tool: drive_files_download
```

Note what is *missing* from the first and third: no `Registered custom tool: gmail_drafts_create`.

## The part that needed care

The registry filter is one line. `gmail_drafts_create` is the risk — it is registered by hand and bypasses the registry entirely, which is exactly the blind spot that let it ship advertising itself as destructive in #24. It is a write even though it never sends, so it is skipped. `drive_files_download` stays: it reads, and its `savePath` writes a local file rather than Drive.

So every assertion goes through a **real `tools/list` handshake**, never through `selectTools` — a unit test over the filter cannot see either hand-registered tool.

**Mutation check.** Reverting the one-line guard (`services.includes("gmail") && !readOnly` → `services.includes("gmail")`):

```
 × exposes exactly the 17 read-only tools
 × lists no tool that advertises itself as a write
 × drops every write the default server exposes
 × drops the hand-registered write and keeps the hand-registered read
 × narrows per service, and the count still matches a real tools/list
 Test Files  1 failed | 5 passed (6)
      Tests  5 failed | 139 passed (144)
```

## Scope of the claim

Kept honest in the README rather than oversold: this constrains the **agent, not the credential**. The token on disk keeps whatever scopes it was granted and anything else on the machine can still use it. `gws auth login --readonly` is what narrows the token; the two are complementary. For an MCP server the agent is the threat model, but that is the limit of the claim.

## Additive

The default server is unchanged, and that is asserted rather than assumed — `tools.length` is still 39, `gmail_drafts_create` and `drive_files_delete` still present. `readOnly` defaults to `false` on both `createServer` and `countRegisteredTools`, so no existing caller changes behaviour.

## Verification

```
$ rm -rf build
$ npm run lint     # tsc --noEmit -p tsconfig.lint.json
(clean)
$ npm run build    # tsc
(clean)
$ npm test
 Test Files  6 passed (6)
      Tests  144 passed (144)      # 137 from #27, +7 here
$ npm audit --audit-level=high
found 0 vulnerabilities
```

Diff against #27's head:

```
 README.md                             | 12 +++++++
 src/__tests__/annotations.e2e.test.ts | 63 ++++++++++++++++++++++++++++++++++-
 src/index.ts                          | 56 +++++++++++++++++++++++--------
 3 files changed, 117 insertions(+), 14 deletions(-)
```

The 7 new tests cover: the 17-tool count via handshake, no listed tool advertising a write, all 22 default writes absent, the hand-registered write dropped and the hand-registered read kept, no destructive tool surviving, the default server unchanged, and per-service narrowing where the count still matches a real `tools/list`.