### PR TITLE
Emit idempotentHint and openWorldHint on all 39 tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, and Tasks 
 
 ## Why?
 
-The `gws` CLI had a built-in MCP server that was [removed in v0.8.0](https://github.com/googleworkspace/cli/pull/275) because it exposed 200-400 tools — causing context window bloat in MCP clients. This server takes a curated approach: you choose which Google services to expose, and only a focused set of high-value, narrowly scoped operations are registered as tools. Every tool declares MCP `readOnlyHint`/`destructiveHint` annotations so clients can reason about side effects and surface clearer consent prompts.
+The `gws` CLI had a built-in MCP server that was [removed in v0.8.0](https://github.com/googleworkspace/cli/pull/275) because it exposed 200-400 tools — causing context window bloat in MCP clients. This server takes a curated approach: you choose which Google services to expose, and only a focused set of high-value, narrowly scoped operations are registered as tools. Every tool declares all four MCP annotation hints — `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` — so clients can reason about side effects, know which writes are safe to retry, and surface clearer consent prompts.
 
 ## Prerequisites
 

--- a/src/__tests__/annotations.e2e.test.ts
+++ b/src/__tests__/annotations.e2e.test.ts
@@ -35,7 +35,12 @@ async function connect(services: string[], readOnly = false): Promise<Client> {
 
 type ListedTool = {
   name: string;
-  annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean };
+  annotations?: {
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
 };
 
 let tools: ListedTool[];
@@ -71,10 +76,11 @@ describe("advertised annotations", () => {
 
   it("gmail_drafts_create is advertised as a non-destructive write", () => {
     // The README's safety argument rests on this tool never sending mail.
-    expect(byName("gmail_drafts_create").annotations).toEqual({
-      readOnlyHint: false,
-      destructiveHint: false,
-    });
+    // Asserts the two hints this test is about; the full four-hint object is
+    // pinned in the idempotentHint/openWorldHint block below.
+    const a = byName("gmail_drafts_create").annotations;
+    expect(a?.readOnlyHint).toBe(false);
+    expect(a?.destructiveHint).toBe(false);
   });
 
   it("drive_files_download is advertised read-only (savePath writes locally, not to Drive)", () => {
@@ -206,5 +212,106 @@ describe("--read-only", () => {
       expect(countRegisteredTools(getToolsForServices(services), services, true)).toBe(listed.length);
       expect(listed.every((t) => (t.annotations as ListedTool["annotations"])?.readOnlyHint === true)).toBe(true);
     }
+  });
+});
+
+describe("idempotentHint / openWorldHint", () => {
+  // Asserted from tools/list, never from buildAnnotations. The builder does not
+  // see drive_files_download or gmail_drafts_create at all — #24 shipped a
+  // wrong hint on the second of those while every builder unit test passed.
+
+  it("every tool advertises openWorldHint", () => {
+    const missing = tools
+      .filter((t) => typeof t.annotations?.openWorldHint !== "boolean")
+      .map((t) => t.name);
+    expect(missing).toEqual([]);
+    // All 39 reach Google Workspace, whose state changes independently of us.
+    expect(tools.filter((t) => t.annotations?.openWorldHint === true).length).toBe(39);
+  });
+
+  it("every write advertises idempotentHint, and no read does", () => {
+    // Only meaningful when readOnlyHint is false; the spec ignores it on reads,
+    // which is the same rule this file already applies to destructiveHint.
+    const writesMissing = tools
+      .filter((t) => t.annotations?.readOnlyHint === false)
+      .filter((t) => typeof t.annotations?.idempotentHint !== "boolean")
+      .map((t) => t.name);
+    expect(writesMissing).toEqual([]);
+
+    const readsCarrying = tools
+      .filter((t) => t.annotations?.readOnlyHint === true)
+      .filter((t) => t.annotations?.idempotentHint !== undefined)
+      .map((t) => t.name);
+    expect(readsCarrying).toEqual([]);
+  });
+
+  it("marks exactly the repeatable writes idempotent", () => {
+    // Values, not shape: a test that only counted booleans would pass with
+    // every one of these flipped. Patches and deletes repeat cleanly; a second
+    // delete errors but adds no further effect.
+    const idempotent = tools
+      .filter((t) => t.annotations?.idempotentHint === true)
+      .map((t) => t.name)
+      .sort();
+    expect(idempotent).toEqual([
+      "calendar_events_delete",
+      "calendar_events_update",
+      "drive_files_delete",
+      "drive_files_update",
+      "gmail_threads_modify",
+      "sheets_values_update",
+      "tasks_tasklists_delete",
+      "tasks_tasklists_update",
+      "tasks_tasks_clear",
+      "tasks_tasks_delete",
+      "tasks_tasks_move",
+      "tasks_tasks_update",
+    ]);
+  });
+
+  it("leaves every creating write non-idempotent", () => {
+    // Each of these produces another entity per call, so a client must not
+    // treat a retry as free. sheets_values_append is the subtle one: it is an
+    // append, not a ranged write like sheets_values_update.
+    const notIdempotent = tools
+      .filter((t) => t.annotations?.idempotentHint === false)
+      .map((t) => t.name)
+      .sort();
+    expect(notIdempotent).toEqual([
+      "calendar_events_insert",
+      "docs_batchUpdate",
+      "docs_create",
+      "drive_files_copy",
+      "drive_files_create",
+      "drive_permissions_create",
+      "gmail_drafts_create",
+      "sheets_values_append",
+      "tasks_tasklists_insert",
+      "tasks_tasks_insert",
+    ]);
+  });
+
+  it("gives the hand-registered tools all the hints the builder would", () => {
+    // The #24 regression in one assertion.
+    expect(byName("gmail_drafts_create").annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    });
+    expect(byName("drive_files_download").annotations).toEqual({
+      readOnlyHint: true,
+      openWorldHint: true,
+    });
+  });
+
+  it("accounts for all 39 tools", () => {
+    const reads = tools.filter((t) => t.annotations?.readOnlyHint === true).length;
+    const idem = tools.filter((t) => t.annotations?.idempotentHint === true).length;
+    const nonIdem = tools.filter((t) => t.annotations?.idempotentHint === false).length;
+    expect(reads).toBe(17);
+    expect(idem + nonIdem).toBe(39 - reads);
+    expect(idem).toBe(12);
+    expect(nonIdem).toBe(10);
   });
 });

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -238,28 +238,58 @@ describe("buildAnnotations mapping", () => {
     ...flags,
   });
 
-  it("readOnly:true -> { readOnlyHint: true } and no destructiveHint", () => {
+  it("readOnly:true -> read hints only, no destructiveHint or idempotentHint", () => {
     const a = buildAnnotations(mk({ readOnly: true }));
-    expect(a).toEqual({ readOnlyHint: true });
+    expect(a).toEqual({ readOnlyHint: true, openWorldHint: true });
     expect(a.destructiveHint).toBeUndefined();
+    // The spec ignores idempotentHint on a read, same rule as destructiveHint.
+    expect(a.idempotentHint).toBeUndefined();
   });
 
-  it("destructive:true -> { readOnlyHint: false, destructiveHint: true }", () => {
+  it("destructive:true -> destructive write, non-idempotent unless flagged", () => {
     const a = buildAnnotations(mk({ destructive: true }));
-    expect(a).toEqual({ readOnlyHint: false, destructiveHint: true });
+    expect(a).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    });
   });
 
-  it("no flags (additive write) -> explicit { readOnlyHint: false, destructiveHint: false }", () => {
+  it("destructive + idempotent -> idempotentHint: true", () => {
+    const a = buildAnnotations(mk({ destructive: true, idempotent: true }));
+    expect(a.idempotentHint).toBe(true);
+    expect(a.destructiveHint).toBe(true);
+  });
+
+  it("no flags (additive write) -> explicit destructiveHint and idempotentHint", () => {
     const a = buildAnnotations(mk({}));
-    expect(a).toEqual({ readOnlyHint: false, destructiveHint: false });
+    expect(a).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    });
     // Not `undefined`: the MCP default for destructiveHint is true, so an
     // omitted hint advertises an additive write as destructive.
     expect(a.destructiveHint).toBe(false);
   });
 
+  it("additive + idempotent -> idempotentHint: true", () => {
+    const a = buildAnnotations(mk({ idempotent: true }));
+    expect(a.idempotentHint).toBe(true);
+    expect(a.destructiveHint).toBe(false);
+  });
+
   it("readOnly wins if both flags are set (defensive)", () => {
     const a = buildAnnotations(mk({ readOnly: true, destructive: true }));
-    expect(a).toEqual({ readOnlyHint: true });
+    expect(a).toEqual({ readOnlyHint: true, openWorldHint: true });
+  });
+
+  it("openWorldHint is true on every branch", () => {
+    for (const flags of [{ readOnly: true }, { destructive: true }, {}, { idempotent: true }]) {
+      expect(buildAnnotations(mk(flags)).openWorldHint).toBe(true);
+    }
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,8 +322,10 @@ export function createServer(
           savePath: z.string().optional().describe("For binary files (images, PDFs): save to this local path instead of returning content inline. The file path is returned in the response."),
         },
         // Read-only: fetches content, never mutates Drive. (savePath writes a
-        // local file, not the user's Drive data.)
-        annotations: { readOnlyHint: true },
+        // local file, not the user's Drive data.) openWorldHint because Drive
+        // changes independently of this server. idempotentHint is omitted on
+        // reads, matching buildAnnotations.
+        annotations: { readOnlyHint: true, openWorldHint: true },
       },
       async (args) => {
         const tmpFile = makeTmpFileName("gws-dl");
@@ -465,7 +467,17 @@ export function createServer(
         // Additive write: creates a draft (never sends). Reversible, non-destructive.
         // destructiveHint must be stated: the MCP default is true, and this is
         // the tool the README leans on for "drafts are never auto-sent".
-        annotations: { readOnlyHint: false, destructiveHint: false },
+        // idempotentHint is false because each call creates another draft. This
+        // tool is hand-registered and bypasses buildAnnotations entirely, which
+        // is exactly how it shipped without a destructiveHint in #24 — so the
+        // e2e test asserts all four hints from a real tools/list, not from the
+        // builder.
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: true,
+        },
       },
       async (args) => {
         try {

--- a/src/services.ts
+++ b/src/services.ts
@@ -34,12 +34,23 @@ export interface ToolDef {
    * `{ readOnlyHint: false, destructiveHint: false }`.
    */
   destructive?: boolean;
+  /**
+   * Repeating the call with the same arguments leaves the account in the same
+   * state as calling it once. Maps to MCP `idempotentHint`.
+   *
+   * Patches and deletes qualify; a delete's second call errors but adds no
+   * further effect. Creates and appends do not — each call produces another
+   * entity. Only meaningful on a write, so reads leave it unset.
+   */
+  idempotent?: boolean;
 }
 
-/** MCP tool annotations derived from a ToolDef's read/destructive flags. */
+/** MCP tool annotations derived from a ToolDef's declarative flags. */
 export interface ToolAnnotationHints {
   readOnlyHint: boolean;
   destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint: boolean;
 }
 
 /**
@@ -54,16 +65,36 @@ export interface ToolAnnotationHints {
  * "non-destructive" — it means the opposite, and the client renders a
  * delete-grade consent prompt for a tool that only creates a draft. Only omit
  * it on a `readOnlyHint: true` tool, where the spec says it is ignored.
+ *
+ * `openWorldHint` is true on every tool: they all reach Google Workspace,
+ * whose state changes independently of this server. That matches the schema
+ * default, so stating it changes no client behaviour — it is documentation,
+ * and it stops the hint being read as "unset because nobody considered it".
+ *
+ * `idempotentHint` is the one that carries weight. It defaults to **false**,
+ * so unlike `destructiveHint` an omission is the safe direction: a client that
+ * assumes a retry is unsafe merely asks again. It is emitted only on writes,
+ * matching how `destructiveHint` is omitted on reads where the spec ignores it.
  */
 export function buildAnnotations(tool: ToolDef): ToolAnnotationHints {
   if (tool.readOnly) {
-    return { readOnlyHint: true };
+    return { readOnlyHint: true, openWorldHint: true };
   }
   if (tool.destructive) {
-    return { readOnlyHint: false, destructiveHint: true };
+    return {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: tool.idempotent === true,
+      openWorldHint: true,
+    };
   }
   // Write-but-additive (or reversible) tool.
-  return { readOnlyHint: false, destructiveHint: false };
+  return {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: tool.idempotent === true,
+    openWorldHint: true,
+  };
 }
 
 export interface ParamDef {
@@ -149,6 +180,7 @@ const driveTools: ToolDef[] = [
     ],
     supportsUpload: true,
     defaultParams: DRIVE_SHARED_DEFAULTS_NO_INCLUDE,
+    idempotent: true,
   },
   {
     name: "drive_files_delete",
@@ -159,6 +191,7 @@ const driveTools: ToolDef[] = [
     ],
     defaultParams: DRIVE_SHARED_DEFAULTS_NO_INCLUDE,
     destructive: true,
+    idempotent: true,
   },
   {
     name: "drive_files_export",
@@ -222,6 +255,7 @@ const sheetsTools: ToolDef[] = [
     bodyParams: [
       { name: "values", description: "2D array of values as JSON string (e.g. '[[\"A\",\"B\"],[\"C\",\"D\"]]')", type: "string", required: true },
     ],
+    idempotent: true,
   },
   {
     name: "sheets_values_append",
@@ -295,6 +329,7 @@ const calendarTools: ToolDef[] = [
       { name: "end", description: "End time JSON", type: "string", required: false },
       { name: "description", description: "Event description", type: "string", required: false },
     ],
+    idempotent: true,
   },
   {
     name: "calendar_events_delete",
@@ -305,6 +340,7 @@ const calendarTools: ToolDef[] = [
       { name: "eventId", description: "Event ID to delete", type: "string", required: true },
     ],
     destructive: true,
+    idempotent: true,
   },
 ];
 
@@ -407,6 +443,7 @@ const gmailTools: ToolDef[] = [
     // trashing) are reversible — untrashing restores the thread. It is a write,
     // not a destructive (irreversible) one, so it stays readOnlyHint:false with
     // no destructiveHint. Permanent deletion is not exposed by this tool.
+    idempotent: true,
   },
 ];
 
@@ -451,6 +488,7 @@ const tasksTools: ToolDef[] = [
     bodyParams: [
       { name: "title", description: "New task list title", type: "string", required: false },
     ],
+    idempotent: true,
   },
   {
     name: "tasks_tasklists_delete",
@@ -460,6 +498,7 @@ const tasksTools: ToolDef[] = [
       { name: "tasklist", description: "Task list ID to delete", type: "string", required: true },
     ],
     destructive: true,
+    idempotent: true,
   },
   {
     name: "tasks_tasks_list",
@@ -521,6 +560,7 @@ const tasksTools: ToolDef[] = [
       { name: "status", description: "Task status: needsAction or completed", type: "string", required: false },
       { name: "due", description: "Due date (RFC 3339)", type: "string", required: false },
     ],
+    idempotent: true,
   },
   {
     name: "tasks_tasks_move",
@@ -533,6 +573,7 @@ const tasksTools: ToolDef[] = [
       { name: "previous", description: "New sibling task ID (move immediately after this task)", type: "string", required: false },
       { name: "destinationTasklist", description: "Destination task list ID (omit to move within the source list)", type: "string", required: false },
     ],
+    idempotent: true,
   },
   {
     name: "tasks_tasks_delete",
@@ -543,6 +584,7 @@ const tasksTools: ToolDef[] = [
       { name: "task", description: "Task ID to delete", type: "string", required: true },
     ],
     destructive: true,
+    idempotent: true,
   },
   {
     name: "tasks_tasks_clear",
@@ -555,6 +597,7 @@ const tasksTools: ToolDef[] = [
     // bulk-mutates list visibility with no per-task undo, so we treat it as
     // destructive alongside the deletes (matches the issue's classification).
     destructive: true,
+    idempotent: true,
   },
 ];
 


### PR DESCRIPTION
The annotation-hints item from conorbronsdon/personal-context#147. Both hints were absent on all 39 tools; the sibling `gsc-mcp` emits all four.

Based on `main` rather than stacked, so it gets real CI — this is the change class that broke in #24, and Windows/Node-matrix signal is worth more here than avoiding a small merge conflict.

## `openWorldHint`: true everywhere

Every tool reaches Google Workspace, whose state changes independently of this server. This **equals the schema default**, so it changes no client behaviour — it is documentation, and it stops the hint reading as "unset because nobody considered it". Low-risk half of this PR.

## `idempotentHint`: a per-tool judgement, not a blanket value

The half that carries weight. Unlike `destructiveHint`, the default here is `false`, so an omission errs *safe*: a client assuming a retry is unsafe merely asks again. That makes setting it `true` the claim that needs justifying.

**12 idempotent** — repeating with the same arguments leaves the same state. Patches, deletes, label sets, ranged writes. A second delete errors but adds no further effect:

`calendar_events_delete`, `calendar_events_update`, `drive_files_delete`, `drive_files_update`, `gmail_threads_modify`, `sheets_values_update`, `tasks_tasklists_delete`, `tasks_tasklists_update`, `tasks_tasks_clear`, `tasks_tasks_delete`, `tasks_tasks_move`, `tasks_tasks_update`

**10 not idempotent** — each call produces another entity:

`calendar_events_insert`, `docs_batchUpdate`, `docs_create`, `drive_files_copy`, `drive_files_create`, `drive_permissions_create`, `gmail_drafts_create`, `sheets_values_append`, `tasks_tasklists_insert`, `tasks_tasks_insert`

`sheets_values_append` is the one worth a second look: it is an *append*, not a ranged write like `sheets_values_update`, so it is the pair most likely to be classified together by mistake. `docs_batchUpdate` likewise — an `insertText` request appends on every call.

17 reads + 12 + 10 = 39. Emitted only on writes, matching how `destructiveHint` is already omitted on reads where the spec ignores it.

## The #24 lesson, applied

`buildAnnotations` never sees `drive_files_download` or `gmail_drafts_create` — both are hand-registered with annotation object literals, which is precisely how `gmail_drafts_create` shipped without a `destructiveHint` while all 244 builder unit tests passed. Both are updated here, and **every assertion goes through a real `tools/list` handshake**, not the builder.

**Two mutations, to show the tests actually bite:**

Drop `openWorldHint` from the hand-registered `drive_files_download`:

```
 × every tool advertises openWorldHint
 × gives the hand-registered tools all the hints the builder would
      Tests  2 failed | 136 passed (138)
```

Only the e2e catches this one — the builder unit tests stay green, exactly as in #24.

Mark `sheets_values_append` idempotent:

```
 × marks exactly the repeatable writes idempotent
 × leaves every creating write non-idempotent
 × accounts for all 39 tools
      Tests  3 failed | 135 passed (138)
```

The idempotent sets are asserted **by name, not by count**, so flipping any single flag fails rather than sliding through a same-shape check.

## Verification

```
$ rm -rf build
$ npm run lint     # tsc --noEmit
(clean)
$ npm run build    # tsc
(clean)
$ npm test
 Test Files  12 passed (12)
      Tests  276 passed (276)
$ npm audit --audit-level=high
found 0 vulnerabilities
```

**On that number:** 276 is 138 distinct tests counted twice. This branch is off `main`, where tests compile to `build/__tests__` and `npm run build` runs before `npm test`, so vitest collects the `.ts` source and the compiled `.js` copy. #27 fixes that; here it just means the honest count is **138 = 129 baseline + 9 new** (6 e2e, 3 in `services.test.ts`).

```
 README.md                             |   2 +-
 src/__tests__/annotations.e2e.test.ts | 117 ++++++++++++++++++++++++++++++++--
 src/__tests__/services.test.ts        |  44 +++++++++++--
 src/index.ts                          |  18 +++++-
 src/services.ts                       |  51 +++++++++++++--
```

Two pre-existing assertions were updated rather than deleted: the `buildAnnotations` unit tests now pin the four-hint shape, and the `gmail_drafts_create` e2e test asserts the two hints it is actually about while the full four-hint object is pinned in the new block.

## Merge note

Touches `src/index.ts` and `src/__tests__/annotations.e2e.test.ts`, which #28 also touches. Expect a small conflict in the test file depending on merge order; the code regions are disjoint.