### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,13 @@ COPY --from=builder /app/build ./build
 # must NOT use --ignore-scripts: with scripts off, the launcher instead fetches
 # the binary on first run, which needs network at tool-call time and write
 # access to a root-owned directory the runtime user does not have.
-# Alpine works because upstream publishes an x86_64-unknown-linux-musl build.
+# Alpine works because upstream publishes an x86_64-unknown-linux-musl build,
+# and an aarch64 one, so multi-arch builds work.
+# Scope of the version pin: it pins the launcher package, not the binary. The
+# postinstall does verify SHA256, but it fetches the checksum from the same
+# mutable GitHub release as the artifact, so that is a corruption check rather
+# than a trust anchor. A build-time failure is loud, not silent — install.js
+# exits 1 and BuildKit aborts the layer.
 RUN npm install -g @googleworkspace/cli@0.22.5
 
 # drive_files_download and any gws --output write a temp file into the working
@@ -32,14 +38,23 @@ RUN chown node:node /app
 #   ~/.config/gws  ->  /home/node/.config/gws in this container
 # so mount the host directory there, or point
 # GOOGLE_WORKSPACE_CLI_CONFIG_DIR at another mounted path.
-# Mount it read-write. gws treats that directory as state, not just input: on
-# Linux it keeps the credential encryption key there as .encryption_key, writes
-# credentials.enc through credentials.tmp when the OAuth token refreshes, and
-# caches tokens and discovery documents in token_cache.json and cache/. A
-# read-only mount still answers introspection, but tool calls degrade once
-# anything needs to be written back.
-# The server starts and answers tools/list with no credentials present; tool
-# calls then fail with the gws error until the credentials are there.
+# Mount it read-write, and make sure the host directory is writable by uid 1000.
+# gws treats that directory as state, not just input, and the first thing it
+# writes is not a credential: it caches the API discovery document under cache/
+# on the FIRST tool call, before authentication is attempted. So a read-only
+# mount does not degrade gracefully, it fails every tool call outright with
+#   error[discovery]: Read-only file system (os error 30)
+# and a directory the runtime user cannot write fails the same way with
+#   error[discovery]: Permission denied (os error 13)
+# It also keeps the credential encryption key here as .encryption_key, since on
+# Linux there is no OS keyring to hold it, next to credentials.enc.
+# That last point is a portability trap worth knowing: a credential minted by
+# `gws auth login` on macOS or Windows has its key in the OS keyring rather than
+# in this directory, so copying the directory alone into a container yields
+# "Decryption failed. Credentials may have been created on a different machine."
+# The server starts and answers tools/list with no credentials present. Tool
+# calls then return isError: true carrying the gws error — with no mount at all
+# that is error[auth]: Access denied. No credentials provided.
 
 USER node
 CMD ["node", "build/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# gws-mcp-server — stdio MCP server for Google Workspace via the gws CLI
+# Build:  docker build -t gws-mcp-server .
+# Run:    docker run -i --rm \
+#           -v "$HOME/.config/gws:/home/node/.config/gws" gws-mcp-server
+
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json tsconfig.json ./
+COPY src ./src
+RUN npm ci --ignore-scripts && npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
+COPY --from=builder /app/build ./build
+
+# The gws CLI is a Rust binary this server shells out to. Its npm package is a
+# launcher whose postinstall downloads the matching release, so this install
+# must NOT use --ignore-scripts: with scripts off, the launcher instead fetches
+# the binary on first run, which needs network at tool-call time and write
+# access to a root-owned directory the runtime user does not have.
+# Alpine works because upstream publishes an x86_64-unknown-linux-musl build.
+RUN npm install -g @googleworkspace/cli@0.22.5
+
+# drive_files_download and any gws --output write a temp file into the working
+# directory, so it has to be writable by the runtime user.
+RUN chown node:node /app
+
+# Credentials are not baked into the image. gws reads them from
+#   ~/.config/gws  ->  /home/node/.config/gws in this container
+# so mount the host directory there, or point
+# GOOGLE_WORKSPACE_CLI_CONFIG_DIR at another mounted path.
+# Mount it read-write. gws treats that directory as state, not just input: on
+# Linux it keeps the credential encryption key there as .encryption_key, writes
+# credentials.enc through credentials.tmp when the OAuth token refreshes, and
+# caches tokens and discovery documents in token_cache.json and cache/. A
+# read-only mount still answers introspection, but tool calls degrade once
+# anything needs to be written back.
+# The server starts and answers tools/list with no credentials present; tool
+# calls then fail with the gws error until the credentials are there.
+
+USER node
+CMD ["node", "build/index.js"]


### PR DESCRIPTION
Adds a Dockerfile so the server can be submitted to `docker/mcp-registry`, which requires an image that starts in a container and answers an MCP introspection request.

Same two-stage `node:22-alpine` shape as the other servers here, with two additions the gws dependency forces. The `gws` CLI is installed globally into the runtime stage without `--ignore-scripts`, because its npm package is a launcher whose postinstall downloads the matching Rust release; with scripts off the launcher defers that fetch to first run, which needs network at tool-call time and write access to a root-owned directory the `node` user does not have. Alpine works because upstream publishes an `x86_64-unknown-linux-musl` build. `/app` is chowned to `node` because `drive_files_download` and any `gws --output` write a temp file into the working directory.

Credentials are not baked into the image. gws reads them from `~/.config/gws`, which is `/home/node/.config/gws` in this container, so that is the mount point. Mount it read-write rather than read-only: gws keeps the credential encryption key there as `.encryption_key` on Linux, rewrites `credentials.enc` through `credentials.tmp` on token refresh, and caches tokens and discovery documents in `token_cache.json` and `cache/`.

Built and introspected locally with no credentials present, which is the registry's hard requirement:

```
$ docker build -t gws-mcp-test .
...
naming to docker.io/library/gws-mcp-test:latest done

$ printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"c","version":"1"}}}' '{"jsonrpc":"2.0","method":"notifications/initialized"}' '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | docker run -i --rm gws-mcp-test

[gws-mcp] Starting with 39 tools from services: drive, sheets, calendar, docs, gmail, tasks
[gws-mcp] Using gws binary: gws
[gws-mcp] Registered custom tool: drive_files_download
[gws-mcp] Registered custom tool: gmail_drafts_create
[gws-mcp] Server running on stdio
{"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{"listChanged":true}},"serverInfo":{"name":"gws-mcp-server","version":"0.4.0"}},"jsonrpc":"2.0","id":1}
{"result":{"tools":[{"name":"drive_files_list", ... }]},"jsonrpc":"2.0","id":2}
```

`tools/list` returns 39 tools. `gws --version` reports `gws 0.22.5` inside the image as uid 1000 (`node`), and introspection also succeeds with a read-only config directory mounted.
