### PR TITLE
ci: tighten audit gate to high + fix the advisories it would catch; correct publish.yml drift claim (#30 item 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm run build
       - run: npm test
       # Keep installs green: block CI on high+ advisories, let moderates through.
-      - run: npm audit --audit-level=critical
+      - run: npm audit --audit-level=high
 
   # Stable aggregation gate: branch protection requires only this one check, so
   # editing the test matrix (OS/node) never orphans a required check name again.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,9 +60,13 @@ jobs:
         if: steps.version.outputs.changed == 'true'
         run: npm publish --provenance
 
-      # server.json is derived from package.json at publish time so the two can
-      # never drift again — the registry stayed pinned at the June 2026 versions
-      # because server.json was hand-maintained and nobody re-published it.
+      # Overwrites server.json in the runner's checkout so the version the
+      # registry receives below always comes from package.json. The write is
+      # never committed, so the server.json in git can still show a stale
+      # version between releases — what this guarantees is the published
+      # artifact, not the file on main. The registry stayed pinned at the
+      # June 2026 versions because server.json was hand-maintained and nobody
+      # re-published it; deriving it here is what fixes that.
       - name: Sync server.json version from package.json
         run: |
           node -e '

--- a/package-lock.json
+++ b/package-lock.json
@@ -1039,9 +1039,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1209,9 +1209,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1260,9 +1260,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
Ships item 1 of #30 — the two workflow-comment fixes that were blocked on a `workflow` token scope. This machine's token has the scope, so the wall in the issue didn't apply; the branch was reconstructed from the patch the issue inlined for exactly this case.

**One material addition over the inlined patch.** The issue's 8/03 verification (`npm audit --audit-level=high` → 0 vulnerabilities) no longer held: fast-uri (GHSA-7p8r-x3mc-p8w7) and ip-address (GHSA-mwp4-54f8-5fhr + two siblings) picked up high advisories since, so tightening the gate alone would have reddened main on the next push. Both fixed in-range via `npm audit fix` — lockfile-only, no package.json change.

Verification on this branch:
- `npm audit --audit-level=high` → exit 0, `found 0 vulnerabilities` (real exit code checked directly, not through a pipe)
- `npm run build` (tsc) clean
- `npm test` → 153/153 pass

**Still open on #30 after this merges:** item 2, the scope-picker checkbox observation — needs a real interactive `gws auth login` OAuth run, Conor-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
