### PR TITLE
Add slides service (5 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ npm install && npm run build
       "command": "npx",
       "args": [
         "gws-mcp-server",
-        "--services", "drive,sheets,calendar,docs,gmail,tasks"
+        "--services", "drive,sheets,calendar,docs,slides,gmail,tasks"
       ]
     }
   }
@@ -113,7 +113,7 @@ This constrains the **agent, not the credential**. The token on disk keeps whate
 
 ### Trimming context cost
 
-Every registered tool rides along in each conversation: the full registry is roughly 27 KB of `tools/list` payload (about 6.7K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
+Every registered tool rides along in each conversation: the full registry is 29,550 B of `tools/list` payload (about 7.4K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
 
 ```bash
 gws-mcp-server --services calendar                       # calendar assistant: 5 tools

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gws-mcp-server
 
-Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, and Tasks as a curated set of 39 [Model Context Protocol](https://modelcontextprotocol.io/) tools, built on the official [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli).
+Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks as a curated set of 44 [Model Context Protocol](https://modelcontextprotocol.io/) tools, built on the official [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli).
 
 [![npm version](https://img.shields.io/npm/v/gws-mcp-server?style=flat-square)](https://www.npmjs.com/package/gws-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
@@ -102,7 +102,7 @@ npm install && npm run build
 
 ### `--read-only`
 
-`--read-only` registers **17 tools** instead of 39. Every tool that writes to Google is left unregistered, so it never appears in `tools/list` and there is nothing for an agent to call — including `gmail_drafts_create`, which is a write even though it never sends. `drive_files_download` stays, since it reads.
+`--read-only` registers **20 tools** instead of 44. Every tool that writes to Google is left unregistered, so it never appears in `tools/list` and there is nothing for an agent to call — including `gmail_drafts_create`, which is a write even though it never sends. `drive_files_download` stays, since it reads.
 
 ```bash
 gws-mcp-server --read-only
@@ -142,6 +142,13 @@ This constrains the **agent, not the credential**. The token on disk keeps whate
 - `docs_create` — Create documents
 - `docs_batchUpdate` — Apply document updates
 
+### `slides` (5 tools)
+- `slides_get` — Get a presentation's slides, layouts, masters, and page elements
+- `slides_create` — Create a blank presentation
+- `slides_batchUpdate` — Apply updates (insert/update/delete slides, text, shapes, tables, etc)
+- `slides_pages_get` — Get a single page (slide, layout, or master)
+- `slides_pages_getThumbnail` — Get a thumbnail image URL for a page
+
 ### `gmail` (6 tools)
 - `gmail_messages_list` — Search messages
 - `gmail_messages_get` — Read a message
@@ -166,7 +173,7 @@ This constrains the **agent, not the credential**. The token on disk keeps whate
 
 > **Update semantics:** the `*_update` tools (calendar events, tasks, task lists) use the Google API's `patch` verb — they merge the fields you supply and leave the rest untouched. To *clear* an existing value, pass it explicitly (e.g. an empty string) rather than omitting it.
 
-**Total: 39 tools** (vs 200-400 in the old implementation)
+**Total: 44 tools** (vs 200-400 in the old implementation)
 
 ## Adding new tools
 
@@ -215,7 +222,7 @@ Issues and pull requests are welcome. The most useful contributions are new tool
 
 ## About
 
-Built and maintained by [Conor Bronsdon](https://github.com/conorbronsdon). I host the [Chain of Thought](https://chainofthought.show/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=gws-mcp-server) podcast, which covers AI infrastructure, developer tools, and how practitioners actually use this stuff. I built this to give the agent workflows that run the show safe, curated access to Gmail, Calendar, Drive, Sheets, Docs, and Tasks.
+Built and maintained by [Conor Bronsdon](https://github.com/conorbronsdon). I host the [Chain of Thought](https://chainofthought.show/?utm_source=github&utm_medium=referral&utm_campaign=repo-readme&utm_content=gws-mcp-server) podcast, which covers AI infrastructure, developer tools, and how practitioners actually use this stuff. I built this to give the agent workflows that run the show safe, curated access to Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks.
 
 <a href="https://glama.ai/mcp/servers/conorbronsdon/gws-mcp-server">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/conorbronsdon/gws-mcp-server/badge" alt="gws-mcp-server MCP server" />

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "google-sheets",
     "google-calendar",
     "google-docs",
+    "google-slides",
     "gmail",
     "google-tasks"
   ],

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.conorbronsdon/gws-mcp-server",
   "title": "Google Workspace MCP Server",
-  "description": "Google Workspace as 39 curated MCP tools: Gmail, Calendar, Drive, Sheets, Docs, and Tasks.",
+  "description": "Google Workspace as 44 curated MCP tools: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks.",
   "repository": {
     "url": "https://github.com/conorbronsdon/gws-mcp-server",
     "source": "github"
@@ -21,9 +21,9 @@
         {
           "type": "named",
           "name": "--services",
-          "description": "Comma-separated list of Google services to expose (drive,sheets,calendar,docs,gmail,tasks). Defaults to all.",
+          "description": "Comma-separated list of Google services to expose (drive,sheets,calendar,docs,slides,gmail,tasks). Defaults to all.",
           "isRequired": false,
-          "default": "drive,sheets,calendar,docs,gmail,tasks"
+          "default": "drive,sheets,calendar,docs,slides,gmail,tasks"
         },
         {
           "type": "named",

--- a/src/__tests__/annotations.e2e.test.ts
+++ b/src/__tests__/annotations.e2e.test.ts
@@ -58,7 +58,7 @@ const byName = (n: string): ListedTool => {
 
 describe("advertised annotations", () => {
   it("registers both hand-written tools alongside the registry tools", () => {
-    expect(tools.length).toBe(39);
+    expect(tools.length).toBe(44);
     expect(byName("drive_files_download")).toBeDefined();
     expect(byName("gmail_drafts_create")).toBeDefined();
   });
@@ -149,8 +149,8 @@ describe("startup tool count", () => {
     // Guards against the fix being "fudge the string": the number has to come
     // from somewhere other than the registry length.
     const registry = getToolsForServices(ALL_SERVICES);
-    expect(registry.length).toBe(37);
-    expect(countRegisteredTools(registry, ALL_SERVICES)).toBe(39);
+    expect(registry.length).toBe(42);
+    expect(countRegisteredTools(registry, ALL_SERVICES)).toBe(44);
     expect(countRegisteredTools(registry, ["sheets"])).toBe(registry.length);
   });
 });
@@ -168,9 +168,9 @@ describe("--read-only", () => {
     roTools = (await client.listTools()).tools as ListedTool[];
   });
 
-  it("exposes exactly the 17 read-only tools", () => {
-    expect(roTools.length).toBe(17);
-    expect(countRegisteredTools(getToolsForServices(ALL_SERVICES), ALL_SERVICES, true)).toBe(17);
+  it("exposes exactly the 20 read-only tools", () => {
+    expect(roTools.length).toBe(20);
+    expect(countRegisteredTools(getToolsForServices(ALL_SERVICES), ALL_SERVICES, true)).toBe(20);
   });
 
   it("lists no tool that advertises itself as a write", () => {
@@ -182,8 +182,8 @@ describe("--read-only", () => {
     const dropped = tools
       .filter((t) => t.annotations?.readOnlyHint !== true)
       .map((t) => t.name);
-    // 39 default - 17 read-only = 22 writes, all gone.
-    expect(dropped.length).toBe(22);
+    // 44 default - 20 read-only = 24 writes, all gone.
+    expect(dropped.length).toBe(24);
     for (const name of dropped) {
       expect(roTools.find((t) => t.name === name)).toBeUndefined();
     }
@@ -200,7 +200,7 @@ describe("--read-only", () => {
   });
 
   it("is additive — the default server is unchanged", () => {
-    expect(tools.length).toBe(39);
+    expect(tools.length).toBe(44);
     expect(tools.find((t) => t.name === "gmail_drafts_create")).toBeDefined();
     expect(tools.find((t) => t.name === "drive_files_delete")).toBeDefined();
   });
@@ -225,8 +225,8 @@ describe("idempotentHint / openWorldHint", () => {
       .filter((t) => typeof t.annotations?.openWorldHint !== "boolean")
       .map((t) => t.name);
     expect(missing).toEqual([]);
-    // All 39 reach Google Workspace, whose state changes independently of us.
-    expect(tools.filter((t) => t.annotations?.openWorldHint === true).length).toBe(39);
+    // All 44 reach Google Workspace, whose state changes independently of us.
+    expect(tools.filter((t) => t.annotations?.openWorldHint === true).length).toBe(44);
   });
 
   it("every write advertises idempotentHint, and no read does", () => {
@@ -286,6 +286,8 @@ describe("idempotentHint / openWorldHint", () => {
       "drive_permissions_create",
       "gmail_drafts_create",
       "sheets_values_append",
+      "slides_batchUpdate",
+      "slides_create",
       "tasks_tasklists_insert",
       "tasks_tasks_insert",
     ]);
@@ -305,13 +307,13 @@ describe("idempotentHint / openWorldHint", () => {
     });
   });
 
-  it("accounts for all 39 tools", () => {
+  it("accounts for all 44 tools", () => {
     const reads = tools.filter((t) => t.annotations?.readOnlyHint === true).length;
     const idem = tools.filter((t) => t.annotations?.idempotentHint === true).length;
     const nonIdem = tools.filter((t) => t.annotations?.idempotentHint === false).length;
-    expect(reads).toBe(17);
-    expect(idem + nonIdem).toBe(39 - reads);
+    expect(reads).toBe(20);
+    expect(idem + nonIdem).toBe(44 - reads);
     expect(idem).toBe(12);
-    expect(nonIdem).toBe(10);
+    expect(nonIdem).toBe(12);
   });
 });

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -434,6 +434,10 @@ describe("slides service shape", () => {
   it("exposes both presentations and pages resources", () => {
     const resources = new Set(slidesTools.map((t) => t.command[1]));
     expect(resources.has("presentations")).toBe(true);
+    // pages is the THIRD command segment, so assert it where it actually lives —
+    // the Set above can never contain "pages".
+    const pagesTools = slidesTools.filter((t) => t.command[2] === "pages");
+    expect(pagesTools.map((t) => t.name).sort()).toEqual(["slides_pages_get", "slides_pages_getThumbnail"]);
   });
 
   it("requires 'presentationId' on every method except create", () => {

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -62,12 +62,13 @@ describe("tool definitions integrity", () => {
     expect(SERVICE_TOOLS["sheets"].length).toBe(4);
     expect(SERVICE_TOOLS["calendar"].length).toBe(5);
     expect(SERVICE_TOOLS["docs"].length).toBe(3);
+    expect(SERVICE_TOOLS["slides"].length).toBe(5);
     expect(SERVICE_TOOLS["gmail"].length).toBe(5);
     expect(SERVICE_TOOLS["tasks"].length).toBe(12);
   });
 
-  it("total tool count is 37", () => {
-    expect(allTools.length).toBe(37);
+  it("total tool count is 42", () => {
+    expect(allTools.length).toBe(42);
   });
 
   it("all params have required fields", () => {
@@ -341,6 +342,7 @@ describe("tool annotation classifications", () => {
       "sheets_get", "sheets_values_get",
       "calendar_events_list", "calendar_events_get",
       "docs_get",
+      "slides_get", "slides_pages_get", "slides_pages_getThumbnail",
       "gmail_messages_list", "gmail_messages_get", "gmail_threads_list", "gmail_threads_get",
       "tasks_tasklists_list", "tasks_tasklists_get", "tasks_tasks_list", "tasks_tasks_get",
     ];
@@ -357,6 +359,7 @@ describe("tool annotation classifications", () => {
       "sheets_values_update", "sheets_values_append",
       "calendar_events_insert", "calendar_events_update",
       "docs_create", "docs_batchUpdate",
+      "slides_create", "slides_batchUpdate",
       "tasks_tasklists_insert", "tasks_tasklists_update",
       "tasks_tasks_insert", "tasks_tasks_update", "tasks_tasks_move",
     ];
@@ -404,15 +407,62 @@ describe("tool annotation classifications", () => {
     }
   });
 
-  it("classification counts match the intended split (16 read / 5 destructive / 16 additive)", () => {
+  it("classification counts match the intended split (19 read / 5 destructive / 18 additive)", () => {
     const read = allTools.filter((t) => buildAnnotations(t).readOnlyHint === true).length;
     const destructive = allTools.filter((t) => buildAnnotations(t).destructiveHint === true).length;
     const additive = allTools.filter(
       (t) => buildAnnotations(t).readOnlyHint === false && buildAnnotations(t).destructiveHint === false,
     ).length;
-    expect(read).toBe(16);
+    expect(read).toBe(19);
     expect(destructive).toBe(5);
-    expect(additive).toBe(16);
+    expect(additive).toBe(18);
     expect(read + destructive + additive).toBe(allTools.length);
+  });
+});
+
+// ── Slides service shape ─────────────────────────────────────────────────
+
+describe("slides service shape", () => {
+  const slidesTools = SERVICE_TOOLS["slides"];
+
+  it("all tools route to the 'slides' gws service", () => {
+    for (const tool of slidesTools) {
+      expect(tool.command[0]).toBe("slides");
+    }
+  });
+
+  it("exposes both presentations and pages resources", () => {
+    const resources = new Set(slidesTools.map((t) => t.command[1]));
+    expect(resources.has("presentations")).toBe(true);
+  });
+
+  it("requires 'presentationId' on every method except create", () => {
+    for (const tool of slidesTools) {
+      if (tool.name === "slides_create") continue;
+      const presentationIdParam = tool.params.find((p) => p.name === "presentationId");
+      expect(presentationIdParam?.required, `${tool.name} should require 'presentationId'`).toBe(true);
+    }
+  });
+
+  it("requires 'pageObjectId' on both pages methods", () => {
+    const pagesOps = slidesTools.filter((t) => t.command[2] === "pages");
+    expect(pagesOps.length).toBe(2);
+    for (const tool of pagesOps) {
+      const pageObjectIdParam = tool.params.find((p) => p.name === "pageObjectId");
+      expect(pageObjectIdParam?.required, `${tool.name} should require 'pageObjectId'`).toBe(true);
+    }
+  });
+
+  it("declares bodyParams on create/batchUpdate and only those", () => {
+    const NEEDS_BODY = new Set(["create", "batchUpdate"]);
+    for (const tool of slidesTools) {
+      const method = tool.command[2];
+      const hasBody = Array.isArray(tool.bodyParams) && tool.bodyParams.length > 0;
+      if (NEEDS_BODY.has(method)) {
+        expect(hasBody, `${tool.name} should declare bodyParams`).toBe(true);
+      } else {
+        expect(hasBody, `${tool.name} should not declare bodyParams`).toBe(false);
+      }
+    }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,14 +7,14 @@
  * wrapping the gws CLI (https://github.com/googleworkspace/cli).
  *
  * Usage:
- *   gws-mcp-server [--services drive,sheets,calendar,docs,gmail,tasks] [--gws-path /path/to/gws]
+ *   gws-mcp-server [--services drive,sheets,calendar,docs,slides,gmail,tasks] [--gws-path /path/to/gws]
  *
  * In .mcp.json:
  *   {
  *     "mcpServers": {
  *       "google-workspace": {
  *         "command": "node",
- *         "args": ["path/to/gws-mcp-server/build/index.js", "--services", "drive,sheets,calendar,docs,gmail,tasks"]
+ *         "args": ["path/to/gws-mcp-server/build/index.js", "--services", "drive,sheets,calendar,docs,slides,gmail,tasks"]
  *       }
  *     }
  *   }

--- a/src/services.ts
+++ b/src/services.ts
@@ -378,6 +378,67 @@ const docsTools: ToolDef[] = [
   },
 ];
 
+// ── Slides ──────────────────────────────────────────────────────────────
+
+const slidesTools: ToolDef[] = [
+  {
+    name: "slides_get",
+    description: "Get a presentation's slides, layouts, masters, and page elements.",
+    command: ["slides", "presentations", "get"],
+    params: [
+      { name: "presentationId", description: "The presentation ID", type: "string", required: true },
+    ],
+    readOnly: true,
+  },
+  {
+    name: "slides_create",
+    description: "Create a new blank presentation.",
+    command: ["slides", "presentations", "create"],
+    params: [],
+    bodyParams: [
+      { name: "title", description: "Presentation title", type: "string", required: true },
+    ],
+    // Additive write: each call creates a new presentation.
+  },
+  {
+    name: "slides_batchUpdate",
+    description: "Apply updates to a presentation (insert/update/delete slides, text, shapes, tables, etc).",
+    command: ["slides", "presentations", "batchUpdate"],
+    params: [
+      { name: "presentationId", description: "The presentation ID", type: "string", required: true },
+    ],
+    bodyParams: [
+      { name: "requests", description: "Array of update requests as JSON string", type: "string", required: true },
+    ],
+    // Additive write, same classification as docs_batchUpdate: requests are
+    // validated and applied atomically, and undo is available in the UI —
+    // this mirrors gmail_threads_modify's TRASH-is-reversible reasoning
+    // rather than treating an update mixing in a delete request as destructive.
+  },
+  {
+    name: "slides_pages_get",
+    description: "Get a single page (slide, layout, or master) from a presentation.",
+    command: ["slides", "presentations", "pages", "get"],
+    params: [
+      { name: "presentationId", description: "The presentation ID", type: "string", required: true },
+      { name: "pageObjectId", description: "The object ID of the page (slide, layout, or master) to retrieve", type: "string", required: true },
+    ],
+    readOnly: true,
+  },
+  {
+    name: "slides_pages_getThumbnail",
+    description: "Get a thumbnail image URL for a page (slide, layout, or master).",
+    command: ["slides", "presentations", "pages", "getThumbnail"],
+    params: [
+      { name: "presentationId", description: "The presentation ID", type: "string", required: true },
+      { name: "pageObjectId", description: "The object ID of the page to render", type: "string", required: true },
+      { name: "thumbnailProperties.mimeType", description: "Thumbnail image format (PNG is the only supported value)", type: "string", required: false },
+      { name: "thumbnailProperties.thumbnailSize", description: "Thumbnail size: THUMBNAIL_SIZE_UNSPECIFIED, LARGE, MEDIUM, SMALL, or WIDTH2000_PX", type: "string", required: false },
+    ],
+    readOnly: true,
+  },
+];
+
 // ── Gmail ───────────────────────────────────────────────────────────────
 
 const gmailTools: ToolDef[] = [
@@ -608,6 +669,7 @@ export const SERVICE_TOOLS: Record<string, ToolDef[]> = {
   sheets: sheetsTools,
   calendar: calendarTools,
   docs: docsTools,
+  slides: slidesTools,
   gmail: gmailTools,
   tasks: tasksTools,
 };

--- a/src/services.ts
+++ b/src/services.ts
@@ -402,7 +402,7 @@ const slidesTools: ToolDef[] = [
   },
   {
     name: "slides_batchUpdate",
-    description: "Apply updates to a presentation (insert/update/delete slides, text, shapes, tables, etc).",
+    description: "Apply updates to a presentation (insert/update/delete slides, text, shapes, tables, etc). Delete requests in a batch are permanent — the API has no undo.",
     command: ["slides", "presentations", "batchUpdate"],
     params: [
       { name: "presentationId", description: "The presentation ID", type: "string", required: true },
@@ -410,10 +410,11 @@ const slidesTools: ToolDef[] = [
     bodyParams: [
       { name: "requests", description: "Array of update requests as JSON string", type: "string", required: true },
     ],
-    // Additive write, same classification as docs_batchUpdate: requests are
-    // validated and applied atomically, and undo is available in the UI —
-    // this mirrors gmail_threads_modify's TRASH-is-reversible reasoning
-    // rather than treating an update mixing in a delete request as destructive.
+    // Classified with docs_batchUpdate/sheets_batchUpdate: an editing write,
+    // not advertised destructive, matching the *_batchUpdate precedent. NOTE
+    // the gmail_threads_modify analogy does NOT hold — trash has an API-level
+    // inverse (untrash), deleteObject does not — so the description carries
+    // the permanence warning instead of the annotation.
   },
   {
     name: "slides_pages_get",


### PR DESCRIPTION
## Summary

Adds a `slides` service exposing Google Slides via `gws slides ...`, following the same curated pattern as the existing `docs`/`sheets` services.

`gws` itself already fully implements Slides (`gws slides presentations get/create/batchUpdate`, `gws slides presentations pages get/getThumbnail`) — this was simply never wired into the MCP registry. Verified all 5 methods work end-to-end against a real presentation before writing this.

New tools:
- `slides_get` — read a presentation's slides, layouts, masters, and page elements
- `slides_create` — create a blank presentation
- `slides_batchUpdate` — apply updates (insert/update/delete slides, text, shapes, tables, etc)
- `slides_pages_get` — read a single page (slide, layout, or master)
- `slides_pages_getThumbnail` — get a thumbnail image URL for a page

Classification: 3 read-only, 2 additive writes (`create`, `batchUpdate` — neither idempotent, consistent with `docs_create`/`docs_batchUpdate`). No destructive tools, matching the existing docs/sheets pattern.

## Checklist

- [x] `npm run lint` and `npm test` pass (158/158, 5 new tests added)
- [x] New tools are narrowly scoped and map to a single `gws` CLI command (keep the curated contract)
- [x] No shell-injection surface: args go through `src/executor.ts`, never string-concatenated commands
- [x] README service/tool list and total count updated (39 → 44)