### PR TITLE
feat(calendar): support attendees + sendUpdates on insert/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ A service's tool count (headers below) tracks its context cost: dropping `tasks`
 ### `calendar` (5 tools)
 - `calendar_events_list` — List events
 - `calendar_events_get` — Get event details
-- `calendar_events_insert` — Create events, optionally with `attendees`. Set `sendUpdates` to actually notify them — it defaults to `none`, so attendees are silently added with no invite sent unless you ask
-- `calendar_events_update` — Update events (only supplied fields change), same `attendees`/`sendUpdates` support as insert
+- `calendar_events_insert` — Create events, optionally with `attendees`. `sendUpdates` controls invitation email (default `none` — no email, though the event may still appear on attendees' calendars depending on their settings)
+- `calendar_events_update` — Update events (only supplied fields change — except `attendees`, which replaces the whole list; omitted attendees are uninvited). Same `sendUpdates` support as insert
 - `calendar_events_delete` — Delete events
 
 ### `docs` (3 tools)

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ This constrains the **agent, not the credential**. The token on disk keeps whate
 ### `calendar` (5 tools)
 - `calendar_events_list` — List events
 - `calendar_events_get` — Get event details
-- `calendar_events_insert` — Create events
-- `calendar_events_update` — Update events (only supplied fields change)
+- `calendar_events_insert` — Create events, optionally with `attendees`. Set `sendUpdates` to actually notify them — it defaults to `none`, so attendees are silently added with no invite sent unless you ask
+- `calendar_events_update` — Update events (only supplied fields change), same `attendees`/`sendUpdates` support as insert
 - `calendar_events_delete` — Delete events
 
 ### `docs` (3 tools)

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -265,13 +265,19 @@ describe("calendar attendees + sendUpdates", () => {
     });
     const jsonIdx = args.indexOf("--json");
     expect(jsonIdx).toBeGreaterThan(-1);
-    const body = JSON.parse(args[jsonIdx + 1]);
-    // Not a string — buildArgs must have parsed it into a real array, since
-    // the Calendar API rejects a stringified attendees field.
-    expect(body.attendees).toEqual([
-      { email: "a@x.com" },
-      { email: "b@x.com", optional: true },
-    ]);
+    // Cross-platform, same convention as the --json assertions above: compare
+    // the escaped string. On Windows escapeJsonArg cmd-quotes the value, so
+    // JSON.parse would return a string and property asserts degrade silently.
+    expect(args[jsonIdx + 1]).toBe(
+      escapeJsonArg(
+        JSON.stringify({
+          summary: "Standup",
+          start: { dateTime: "2026-03-10T10:00:00-07:00" },
+          end: { dateTime: "2026-03-10T10:30:00-07:00" },
+          attendees: [{ email: "a@x.com" }, { email: "b@x.com", optional: true }],
+        })
+      )
+    );
   });
 
   it("sendUpdates lands in --params, never in the --json body", () => {
@@ -283,8 +289,10 @@ describe("calendar attendees + sendUpdates", () => {
     });
     const paramsIdx = args.indexOf("--params");
     const jsonIdx = args.indexOf("--json");
-    expect(JSON.parse(args[paramsIdx + 1]).sendUpdates).toBe("all");
-    expect(JSON.parse(args[jsonIdx + 1]).sendUpdates).toBeUndefined();
+    expect(args[paramsIdx + 1]).toBe(
+      escapeJsonArg(JSON.stringify({ calendarId: "primary", eventId: "evt123", sendUpdates: "all" }))
+    );
+    expect(args[jsonIdx + 1]).toBe(escapeJsonArg(JSON.stringify({ attendees: [{ email: "a@x.com" }] })));
   });
 
   it("omitting attendees/sendUpdates keeps existing insert/update calls unchanged", () => {

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -227,6 +227,79 @@ describe("calendar_events_update (patch semantics)", () => {
   });
 });
 
+// ── Calendar attendees + sendUpdates ─────────────────────────────────────
+// calendar_events_insert/update previously had no way to invite anyone: the
+// request body accepts `attendees` and the real API only emails them when
+// `sendUpdates` is set on the request — neither was exposed, so an event
+// created through this tool never notified its guests.
+
+describe("calendar attendees + sendUpdates", () => {
+  const insertTool = SERVICE_TOOLS["calendar"].find((t) => t.name === "calendar_events_insert")!;
+  const updateTool = SERVICE_TOOLS["calendar"].find((t) => t.name === "calendar_events_update")!;
+
+  it("insert and update both declare an optional 'attendees' bodyParam", () => {
+    for (const tool of [insertTool, updateTool]) {
+      const attendees = tool.bodyParams!.find((p) => p.name === "attendees");
+      expect(attendees, `${tool.name} should declare 'attendees'`).toBeDefined();
+      expect(attendees!.required).toBe(false);
+      expect(attendees!.type).toBe("string");
+    }
+  });
+
+  it("insert and update both declare an optional 'sendUpdates' param (query, not body)", () => {
+    for (const tool of [insertTool, updateTool]) {
+      const sendUpdates = tool.params.find((p) => p.name === "sendUpdates");
+      expect(sendUpdates, `${tool.name} should declare 'sendUpdates'`).toBeDefined();
+      expect(sendUpdates!.required).toBe(false);
+      expect(tool.bodyParams!.find((p) => p.name === "sendUpdates")).toBeUndefined();
+    }
+  });
+
+  it("a JSON-string attendees value is parsed into a real array in the request body", () => {
+    const args = buildArgs(insertTool, {
+      calendarId: "primary",
+      summary: "Standup",
+      start: '{"dateTime":"2026-03-10T10:00:00-07:00"}',
+      end: '{"dateTime":"2026-03-10T10:30:00-07:00"}',
+      attendees: '[{"email":"a@x.com"},{"email":"b@x.com","optional":true}]',
+    });
+    const jsonIdx = args.indexOf("--json");
+    expect(jsonIdx).toBeGreaterThan(-1);
+    const body = JSON.parse(args[jsonIdx + 1]);
+    // Not a string — buildArgs must have parsed it into a real array, since
+    // the Calendar API rejects a stringified attendees field.
+    expect(body.attendees).toEqual([
+      { email: "a@x.com" },
+      { email: "b@x.com", optional: true },
+    ]);
+  });
+
+  it("sendUpdates lands in --params, never in the --json body", () => {
+    const args = buildArgs(updateTool, {
+      calendarId: "primary",
+      eventId: "evt123",
+      attendees: '[{"email":"a@x.com"}]',
+      sendUpdates: "all",
+    });
+    const paramsIdx = args.indexOf("--params");
+    const jsonIdx = args.indexOf("--json");
+    expect(JSON.parse(args[paramsIdx + 1]).sendUpdates).toBe("all");
+    expect(JSON.parse(args[jsonIdx + 1]).sendUpdates).toBeUndefined();
+  });
+
+  it("omitting attendees/sendUpdates keeps existing insert/update calls unchanged", () => {
+    // Regression guard: a caller that never passes the new fields must see
+    // the exact same body as before this change.
+    const args = buildArgs(updateTool, {
+      calendarId: "primary",
+      eventId: "evt123",
+      summary: "New title",
+    });
+    const jsonIdx = args.indexOf("--json");
+    expect(args[jsonIdx + 1]).toBe(escapeJsonArg(JSON.stringify({ summary: "New title" })));
+  });
+});
+
 // ── Tool annotations (issue #5) ──────────────────────────────────────────
 
 describe("buildAnnotations mapping", () => {

--- a/src/services.ts
+++ b/src/services.ts
@@ -306,7 +306,7 @@ const calendarTools: ToolDef[] = [
     command: ["calendar", "events", "insert"],
     params: [
       { name: "calendarId", description: "Calendar ID", type: "string", required: true },
-      { name: "sendUpdates", description: "Whether to notify attendees: \"all\", \"externalOnly\", or \"none\" (default: none — no invites are sent even if attendees is set)", type: "string", required: false },
+      { name: "sendUpdates", description: "Sends invitation email to attendees when set: \"all\", \"externalOnly\", or \"none\" (default: none — no email, though the event may still appear on an attendee's calendar depending on their settings)", type: "string", required: false },
     ],
     bodyParams: [
       { name: "summary", description: "Event title", type: "string", required: true },
@@ -324,14 +324,14 @@ const calendarTools: ToolDef[] = [
     params: [
       { name: "calendarId", description: "Calendar ID", type: "string", required: true },
       { name: "eventId", description: "Event ID to update", type: "string", required: true },
-      { name: "sendUpdates", description: "Whether to notify attendees: \"all\", \"externalOnly\", or \"none\" (default: none — no invites/updates are sent even if attendees is set)", type: "string", required: false },
+      { name: "sendUpdates", description: "Sends update email to attendees when set: \"all\", \"externalOnly\", or \"none\" (default: none — no email). With \"all\" or \"externalOnly\", attendees removed by this update receive a cancellation email", type: "string", required: false },
     ],
     bodyParams: [
       { name: "summary", description: "Event title", type: "string", required: false },
       { name: "start", description: "Start time JSON", type: "string", required: false },
       { name: "end", description: "End time JSON", type: "string", required: false },
       { name: "description", description: "Event description", type: "string", required: false },
-      { name: "attendees", description: "Attendees (JSON array as string, e.g. '[{\"email\":\"a@x.com\"},{\"email\":\"b@x.com\",\"optional\":true}]')", type: "string", required: false },
+      { name: "attendees", description: "REPLACES the full attendee list — Google's patch overwrites array fields, so include everyone who should remain; anyone omitted is uninvited. JSON array as string, e.g. '[{\"email\":\"a@x.com\"},{\"email\":\"b@x.com\",\"optional\":true}]'", type: "string", required: false },
     ],
     idempotent: true,
   },

--- a/src/services.ts
+++ b/src/services.ts
@@ -306,6 +306,7 @@ const calendarTools: ToolDef[] = [
     command: ["calendar", "events", "insert"],
     params: [
       { name: "calendarId", description: "Calendar ID", type: "string", required: true },
+      { name: "sendUpdates", description: "Whether to notify attendees: \"all\", \"externalOnly\", or \"none\" (default: none — no invites are sent even if attendees is set)", type: "string", required: false },
     ],
     bodyParams: [
       { name: "summary", description: "Event title", type: "string", required: true },
@@ -313,6 +314,7 @@ const calendarTools: ToolDef[] = [
       { name: "end", description: "End time JSON", type: "string", required: true },
       { name: "description", description: "Event description", type: "string", required: false },
       { name: "location", description: "Event location", type: "string", required: false },
+      { name: "attendees", description: "Attendees (JSON array as string, e.g. '[{\"email\":\"a@x.com\"},{\"email\":\"b@x.com\",\"optional\":true}]')", type: "string", required: false },
     ],
   },
   {
@@ -322,12 +324,14 @@ const calendarTools: ToolDef[] = [
     params: [
       { name: "calendarId", description: "Calendar ID", type: "string", required: true },
       { name: "eventId", description: "Event ID to update", type: "string", required: true },
+      { name: "sendUpdates", description: "Whether to notify attendees: \"all\", \"externalOnly\", or \"none\" (default: none — no invites/updates are sent even if attendees is set)", type: "string", required: false },
     ],
     bodyParams: [
       { name: "summary", description: "Event title", type: "string", required: false },
       { name: "start", description: "Start time JSON", type: "string", required: false },
       { name: "end", description: "End time JSON", type: "string", required: false },
       { name: "description", description: "Event description", type: "string", required: false },
+      { name: "attendees", description: "Attendees (JSON array as string, e.g. '[{\"email\":\"a@x.com\"},{\"email\":\"b@x.com\",\"optional\":true}]')", type: "string", required: false },
     ],
     idempotent: true,
   },


### PR DESCRIPTION
## Summary

`calendar_events_insert`/`calendar_events_update` had no way to invite anyone. The Calendar API's request body accepts `attendees`, and only actually emails them when `sendUpdates` is set on the request (query param, not body) — neither was exposed by this server, so an event created through it never notified its guests. Found this the hard way: created an event through the tool, then had to go verify against the real Calendar API schema (`--dry-run`) to confirm `attendees` was even a valid body field before wiring it up here.

- `attendees` — JSON array as string, same convention this repo already uses for `parents` (drive) and `values` (sheets); `buildArgs`'s existing string→JSON parsing handles it, no executor changes needed.
- `sendUpdates` — query param (`"all" | "externalOnly" | "none"`), added to `params` not `bodyParams`. Defaults to `"none"` (Google's own default), so existing callers see no behavior change.

Scoped to insert/update only, matching where the gap was actually hit — `delete`'s own `sendUpdates` (for cancellation notices) is a separate concern, left out to keep this focused.

## Checklist

- [x] `npm run lint`, `npm run build`, and `npm test` pass (158/158, 5 new tests added)
- [x] Verified against the real Calendar API schema via `gws calendar events insert --dry-run` before writing any code
- [x] New params are optional and additive — no existing call site's body/params shape changes
- [x] No shell-injection surface: attendees goes through the same `--json` escaping path every other bodyParam uses
- [x] README calendar section updated to mention `attendees`/`sendUpdates`