### PR TITLE
docs: show how to trim tool-surface context cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,24 @@ gws-mcp-server --read-only --services drive,calendar   # combines with -s
 
 This constrains the **agent, not the credential**. The token on disk keeps whatever scopes it was granted, and anything else on the machine can still use it. `gws auth login --readonly` is what narrows the token; the two are complementary. For an MCP server the agent is the threat model, but that is the limit of the claim.
 
+### Trimming context cost
+
+Every registered tool rides along in each conversation: the full registry is roughly 27 KB of `tools/list` payload (about 6.7K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
+
+```bash
+gws-mcp-server --services calendar                       # calendar assistant: 5 tools
+gws-mcp-server --services drive,docs                     # document work, nothing else
+gws-mcp-server --read-only --services drive,docs,sheets  # research setup: reads only
+```
+
+In `.mcp.json` or `claude_desktop_config.json`, the same trimming is just editing the `args` array:
+
+```json
+"args": ["gws-mcp-server", "--services", "drive,calendar"]
+```
+
+A service's tool count (headers below) tracks its context cost: dropping `tasks` (12 tools) saves the most, `docs` (3 tools) the least. There is no per-tool exclude flag today — if service granularity is too coarse for your setup, [open an issue](https://github.com/conorbronsdon/gws-mcp-server/issues) describing the split you need.
+
 ## Available services & tools
 
 ### `drive` (9 tools)


### PR DESCRIPTION
README gains a Trimming context cost section under Options: measured payload figure (~27 KB / ~6.7K tokens, stdio tools/list probe), --services + --read-only composition examples, .mcp.json args equivalent, pointer to issues for per-tool granularity. Follows the tool-bloat discussion on #34/#36.