### PR TITLE
docs: add yt-analytics-mcp to the analytics siblings table

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,10 +249,11 @@ Worth saying plainly: Google's official Gmail MCP server is also draft-only, wit
 |---|---|
 | Google Workspace | this repo |
 | Search Console | [gsc-mcp](https://github.com/conorbronsdon/gsc-mcp) — same curated approach, including derived views like `gsc_striking_distance` |
+| YouTube Analytics | [yt-analytics-mcp](https://github.com/conorbronsdon/yt-analytics-mcp) — owner-side channel, video, and playlist metrics; read-only, nine tools |
 | Google Analytics 4 | [googleanalytics/google-analytics-mcp](https://github.com/googleanalytics/google-analytics-mcp) — Google's own, read-only |
 | BigQuery | [googleapis/mcp-toolbox](https://github.com/googleapis/mcp-toolbox) — Google's own |
 
-These are separate credential families, not one login: Workspace authenticates with `gws auth login`, Search Console with a `webmasters` OAuth credential, GA4 with Application Default Credentials scoped `analytics.readonly`. Nothing here shares a token with anything else.
+These are separate credential families, not one login: Workspace authenticates with `gws auth login`, Search Console with a `webmasters` OAuth credential, YouTube Analytics with a `yt-analytics.readonly` OAuth credential, GA4 with Application Default Credentials scoped `analytics.readonly`. Nothing here shares a token with anything else.
 
 ## About
 


### PR DESCRIPTION
## Summary

[yt-analytics-mcp](https://github.com/conorbronsdon/yt-analytics-mcp) went public today — owner-side YouTube Analytics as nine read-only MCP tools (watch time, traffic sources, audience retention, geography, playlist metrics, and an episode-over-episode comparison). It is the YouTube leg of the same suite this table already describes.

Two lines change:

- A **YouTube Analytics** row in the siblings table, placed after Search Console so the two curated first-party servers sit together above the two Google-owned ones.
- The credential-families sentence under the table now names YouTube's auth path. Adding the row without this would have left the sentence enumerating three of four credential families while the table showed four — the kind of drift that reads as an oversight to anyone counting.

No tool or code changes.

## Checklist

- [x] Docs only — no tool surface change, so no annotation or test impact
- [x] Link verified live (HTTP 200)
- [x] Sentence below the table kept in sync with the table itself