### PR TITLE
fix(deps): bump nanoid to 3.3.18 to clear the high-severity audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1643,9 +1643,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Why

Both open PRs (#34, #35) are red on all four platforms, and neither touched a dependency. The step breakdown shows why: `npm test` **passes** at step 7, and step 8 — `npm audit --audit-level=high` — is what fails, on [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (nanoid <3.3.17 loops indefinitely when a custom generator gets size zero).

The advisory was published **2026-07-29**, but GitHub reviewed it at **2026-08-07T20:50:34Z** — 19 minutes after the last green run and before the first red one. So what changed was the review status of an existing advisory entering npm's audit feed, not a new publication. Worth recording, because the next person debugging a repeat of this will search for a newly-published CVE and find nothing.

nanoid is dev-only, four levels deep: `vitest -> vite -> postcss -> nanoid`. `npm audit --omit=dev` reports 0 vulnerabilities, so the published package was never exposed — only the test toolchain.

## What

Plain `npm audit fix` output: three lockfile lines, nanoid 3.3.16 -> 3.3.18, no `package.json` change.

Lockfile-only is deliberate. `publish.yml` triggers on pushes to main filtered to `paths: [package.json]`, so touching that file would fire a Publish run — which currently fails at the MCP-registry step with `invalid version: cannot publish duplicate version` (npm and package.json are both at 0.4.0, the registry search API reports 0.2.0, so the gate says publish and the registry rejects it). That is a real pre-existing bug worth its own issue; this PR simply declines to trigger it.

## Verification

Clean worktree, full gate: lint clean, build clean, **153/153**, and `npm audit --audit-level=high` exits 0 after `npm ci` — the lockfile alone resolves 3.3.18.

Negative control run before trusting that green: restoring main's lockfile and reinstalling returns **exit 1** and re-reports the advisory. The gate still fires; it hasn't been silenced.

## Not included, deliberately

Adding `--omit=dev` to the audit step would stop dev-only advisories from ever gating contributor PRs again. That is a change to what the gate is *for* — a security-posture decision, not a dependency bump — so it belongs in its own PR.