### PR TITLE
docs: re-hedge the tools/list payload figure, which was stale on arrival

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This constrains the **agent, not the credential**. The token on disk keeps whate
 
 ### Trimming context cost
 
-Every registered tool rides along in each conversation: the full registry is 29,550 B of `tools/list` payload (about 7.4K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
+Every registered tool rides along in each conversation: the full registry is roughly 30 KB of `tools/list` payload (about 7.6K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
 
 ```bash
 gws-mcp-server --services calendar                       # calendar assistant: 5 tools


### PR DESCRIPTION
#34 replaced a hedge ("roughly 27 KB") with an exact `29,550 B`. That number was already wrong when it merged, and is wronger now.

It was measured before the review suggestion that moved the permanence warning into `slides_batchUpdate`'s description — lengthening a description lengthens the payload, so it no longer described the branch it shipped on. Then #35 added `attendees` and `sendUpdates` to calendar insert/update, each carrying a long description, and moved it another ~950 B.

## Measured

Driving a real MCP client over the in-memory transport (the harness `annotations.e2e.test.ts` already uses) and taking `Buffer.byteLength` of the `tools/list` response, on this commit:

| | |
|---|---|
| Tools | 44 |
| Payload | **30,574 B** (29.9 KB) |
| README claimed | 29,550 B |

Off by just over 1 KB.

## Why a hedge rather than the new number

Nothing in the repo gates that figure, so an exact byte count re-rots every time any tool description is edited — which is roughly every feature PR. Two data points in two consecutive PRs is enough evidence for the general case. The hedge survives small edits; an exact literal in prose does not.

If an exact number is wanted, it needs a test that computes it from the registry. I'd rather file that separately than decide it here, because the interesting part is a maintainer call: what tolerance band, and does drift fail the build or just warn.

Verification: lint clean, build clean, full suite green — this is a one-line README change, but the payload figure itself was measured rather than estimated.