### PR TITLE
docs: align batchUpdate permanence warnings

### DIFF
--- a/src/services.ts
+++ b/src/services.ts
@@ -371,7 +371,7 @@ const docsTools: ToolDef[] = [
   },
   {
     name: "docs_batchUpdate",
-    description: "Apply updates to a Google Doc (insert text, formatting, etc).",
+    description: "Apply updates to a Google Doc (insert/delete text, formatting, etc). Delete requests in a batch can permanently remove content — the API has no automatic undo.",
     command: ["docs", "documents", "batchUpdate"],
     params: [
       { name: "documentId", description: "The document ID", type: "string", required: true },
@@ -414,11 +414,9 @@ const slidesTools: ToolDef[] = [
     bodyParams: [
       { name: "requests", description: "Array of update requests as JSON string", type: "string", required: true },
     ],
-    // Classified with docs_batchUpdate/sheets_batchUpdate: an editing write,
-    // not advertised destructive, matching the *_batchUpdate precedent. NOTE
-    // the gmail_threads_modify analogy does NOT hold — trash has an API-level
-    // inverse (untrash), deleteObject does not — so the description carries
-    // the permanence warning instead of the annotation.
+    // Editing write with mixed request types; some delete variants have no
+    // API-level inverse. The description carries a permanence warning while
+    // #40 tracks the separate destructiveHint policy decision.
   },
   {
     name: "slides_pages_get",


### PR DESCRIPTION
## What changed

- Warn that `docs_batchUpdate` requests can permanently remove content and have no automatic API undo.
- Remove the stale source comment that referred to a nonexistent `sheets_batchUpdate` tool.
- Keep the existing `destructiveHint` classification unchanged.

## Why

Issue #40 says all batch-update tools carry honest description-level warnings while the annotation policy remains undecided. Current `main` only warns on `slides_batchUpdate`; `docs_batchUpdate` omits the warning, and the adjacent comment names a Sheets tool this server does not expose.

This makes the documented interim policy true without pre-empting the maintainer decision in #40.

## Impact

Documentation/tool-description only. No command, schema, or annotation behavior changes.

## Validation

- GitHub Actions CI: passed ([run 31672516576](https://github.com/conorbronsdon/gws-mcp-server/actions/runs/31672516576))
- Branch comparison: one commit, one file, 4 additions / 6 deletions

Related: #40