### PR TITLE
Advertise destructive batchUpdate capabilities

### DIFF
--- a/src/__tests__/annotations.e2e.test.ts
+++ b/src/__tests__/annotations.e2e.test.ts
@@ -105,7 +105,7 @@ describe("advertised annotations", () => {
     expect(SERVER_VERSION).toBe(pkg.version);
   });
 
-  it("only irreversible removals are advertised as destructive", () => {
+  it("advertises every tool capable of irreversible removal as destructive", () => {
     // tasks_tasks_clear is in this list and is not a *_delete: it permanently
     // removes completed tasks from a list, so it belongs here.
     const destructive = tools
@@ -114,7 +114,9 @@ describe("advertised annotations", () => {
       .sort();
     expect(destructive).toEqual([
       "calendar_events_delete",
+      "docs_batchUpdate",
       "drive_files_delete",
+      "slides_batchUpdate",
       "tasks_tasklists_delete",
       "tasks_tasks_clear",
       "tasks_tasks_delete",
@@ -291,6 +293,11 @@ describe("idempotentHint / openWorldHint", () => {
       "tasks_tasklists_insert",
       "tasks_tasks_insert",
     ]);
+  });
+
+  it("marks batchUpdate tools that can permanently delete content as destructive", () => {
+    expect(byName("docs_batchUpdate").annotations?.destructiveHint).toBe(true);
+    expect(byName("slides_batchUpdate").annotations?.destructiveHint).toBe(true);
   });
 
   it("gives the hand-registered tools all the hints the builder would", () => {

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -406,6 +406,8 @@ describe("tool annotation classifications", () => {
     const expectDestructive = [
       "drive_files_delete",
       "calendar_events_delete",
+      "docs_batchUpdate",
+      "slides_batchUpdate",
       "tasks_tasklists_delete",
       "tasks_tasks_delete",
       "tasks_tasks_clear",
@@ -439,8 +441,8 @@ describe("tool annotation classifications", () => {
       "drive_files_create", "drive_files_copy", "drive_files_update", "drive_permissions_create",
       "sheets_values_update", "sheets_values_append",
       "calendar_events_insert", "calendar_events_update",
-      "docs_create", "docs_batchUpdate",
-      "slides_create", "slides_batchUpdate",
+      "docs_create",
+      "slides_create",
       "tasks_tasklists_insert", "tasks_tasklists_update",
       "tasks_tasks_insert", "tasks_tasks_update", "tasks_tasks_move",
     ];
@@ -488,15 +490,15 @@ describe("tool annotation classifications", () => {
     }
   });
 
-  it("classification counts match the intended split (19 read / 5 destructive / 18 additive)", () => {
+  it("classification counts match the intended split (19 read / 7 destructive / 16 additive)", () => {
     const read = allTools.filter((t) => buildAnnotations(t).readOnlyHint === true).length;
     const destructive = allTools.filter((t) => buildAnnotations(t).destructiveHint === true).length;
     const additive = allTools.filter(
       (t) => buildAnnotations(t).readOnlyHint === false && buildAnnotations(t).destructiveHint === false,
     ).length;
     expect(read).toBe(19);
-    expect(destructive).toBe(5);
-    expect(additive).toBe(18);
+    expect(destructive).toBe(7);
+    expect(additive).toBe(16);
     expect(read + destructive + additive).toBe(allTools.length);
   });
 });

--- a/src/services.ts
+++ b/src/services.ts
@@ -371,7 +371,7 @@ const docsTools: ToolDef[] = [
   },
   {
     name: "docs_batchUpdate",
-    description: "Apply updates to a Google Doc (insert text, formatting, etc).",
+    description: "Apply updates to a Google Doc (insert, format, replace, or permanently delete content).",
     command: ["docs", "documents", "batchUpdate"],
     params: [
       { name: "documentId", description: "The document ID", type: "string", required: true },
@@ -379,6 +379,9 @@ const docsTools: ToolDef[] = [
     bodyParams: [
       { name: "requests", description: "Array of update requests as JSON string", type: "string", required: true },
     ],
+    // The request union includes deleteContentRange. An individual call may be
+    // additive, but the annotation describes the tool's worst-case capability.
+    destructive: true,
   },
 ];
 
@@ -414,11 +417,10 @@ const slidesTools: ToolDef[] = [
     bodyParams: [
       { name: "requests", description: "Array of update requests as JSON string", type: "string", required: true },
     ],
-    // Classified with docs_batchUpdate/sheets_batchUpdate: an editing write,
-    // not advertised destructive, matching the *_batchUpdate precedent. NOTE
-    // the gmail_threads_modify analogy does NOT hold — trash has an API-level
-    // inverse (untrash), deleteObject does not — so the description carries
-    // the permanence warning instead of the annotation.
+    // The request union includes deleteObject and deleteSlide. An individual
+    // call may be additive, but the annotation describes the tool's worst-case
+    // capability; unlike Gmail trash, these operations have no API-level undo.
+    destructive: true,
   },
   {
     name: "slides_pages_get",


### PR DESCRIPTION
Closes #40.

## What changed

- marks `docs_batchUpdate` and `slides_batchUpdate` with `destructiveHint: true`
- makes the Docs description explicit that request batches may permanently delete content
- pins both annotations in the assembled `tools/list` payload and registry-level classification tests
- updates the classification totals from 5 to 7 destructive tools

There is no `sheets_batchUpdate` tool in the current curated registry, so this covers both exposed batchUpdate tools.

## Why

MCP annotations describe a tool's capability, not its most frequent request. Both request unions contain permanent delete operations with no API-level inverse. Advertising either tool as non-destructive understates the authority an agent receives.

## Verification

- `npm run lint`
- `npm run build`
- `npm test` — 164/164 passing
- `git diff --check`