### PR TITLE
Fix publish registry gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,6 +68,7 @@ jobs:
       # June 2026 versions because server.json was hand-maintained and nobody
       # re-published it; deriving it here is what fixes that.
       - name: Sync server.json version from package.json
+        if: steps.version.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           node -e '
             const fs = require("fs");
@@ -79,31 +80,40 @@ jobs:
           '
           node -p "\"server.json is now at \" + require('./server.json').version"
 
-      # Checked independently of the npm gate above: npm and the registry can be
-      # out of sync on their own, so a workflow_dispatch has to be able to push a
-      # registry-only catch-up without an npm version bump.
+      # A package.json-only push with no version bump is a no-op. A manual
+      # dispatch can still perform a registry-only catch-up when npm and the
+      # registry are out of sync.
       - name: Check if version is already in the MCP registry
+        if: steps.version.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         id: registry
         run: |
           SERVER_NAME="$(node -p "require('./package.json').mcpName")"
           LOCAL_VERSION="${{ steps.version.outputs.local }}"
-          if curl -fsSL "https://registry.modelcontextprotocol.io/v0.1/servers?search=$SERVER_NAME" -o registry.json; then
-            REGISTRY_VERSION="$(SERVER_NAME="$SERVER_NAME" node -p "const r = JSON.parse(require('fs').readFileSync('registry.json', 'utf8')).servers || []; const m = r.find(s => s.server && s.server.name === process.env.SERVER_NAME); m ? m.server.version : 'none'")"
-          else
-            REGISTRY_VERSION=unknown
-            echo "Registry lookup failed — will attempt the publish and let it decide."
-          fi
-          rm -f registry.json
-          if [ "$LOCAL_VERSION" = "$REGISTRY_VERSION" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "MCP registry already has $SERVER_NAME@$LOCAL_VERSION — nothing to do."
+          SERVER_NAME_ENCODED="$(SERVER_NAME="$SERVER_NAME" node -p "encodeURIComponent(process.env.SERVER_NAME)")"
+          LOCAL_VERSION_ENCODED="$(LOCAL_VERSION="$LOCAL_VERSION" node -p "encodeURIComponent(process.env.LOCAL_VERSION)")"
+          REGISTRY_URL="https://registry.modelcontextprotocol.io/v0.1/servers/$SERVER_NAME_ENCODED/versions/$LOCAL_VERSION_ENCODED"
+          if REGISTRY_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' "$REGISTRY_URL")"; then
+            case "$REGISTRY_STATUS" in
+              200)
+                echo "changed=false" >> "$GITHUB_OUTPUT"
+                echo "MCP registry already has $SERVER_NAME@$LOCAL_VERSION — nothing to do."
+                ;;
+              404)
+                echo "changed=true" >> "$GITHUB_OUTPUT"
+                echo "MCP registry does not have $SERVER_NAME@$LOCAL_VERSION — publishing."
+                ;;
+              *)
+                echo "changed=true" >> "$GITHUB_OUTPUT"
+                echo "Registry lookup returned HTTP $REGISTRY_STATUS — will attempt the publish and let it decide."
+                ;;
+            esac
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "MCP registry has $REGISTRY_VERSION, package.json is $LOCAL_VERSION — publishing."
+            echo "Registry lookup failed — will attempt the publish and let it decide."
           fi
 
       - name: Publish to the MCP registry
-        if: steps.registry.outputs.changed == 'true'
+        if: (steps.version.outputs.changed == 'true' || github.event_name == 'workflow_dispatch') && steps.registry.outputs.changed == 'true'
         # Pinned: an unpinned /latest/ URL silently changes the CLI under CI.
         run: |
           curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.8.0/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher

--- a/src/__tests__/publish-workflow.test.ts
+++ b/src/__tests__/publish-workflow.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  new URL("../../.github/workflows/publish.yml", import.meta.url),
+  "utf8",
+);
+
+function stepNamed(name: string): string {
+  const marker = `      - name: ${name}\n`;
+  const start = workflow.indexOf(marker);
+  if (start === -1) throw new Error(`publish workflow has no "${name}" step`);
+
+  const next = workflow.indexOf("\n      - name:", start + marker.length);
+  return workflow.slice(start, next === -1 ? undefined : next);
+}
+
+const registryLegGuard =
+  "steps.version.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'";
+
+describe("publish workflow registry gate", () => {
+  it.each([
+    "Sync server.json version from package.json",
+    "Check if version is already in the MCP registry",
+  ])("gates %s on a new npm version or a manual catch-up", (name) => {
+    expect(stepNamed(name)).toContain(`if: ${registryLegGuard}`);
+  });
+
+  it("publishes to the registry only when the gated lookup finds a missing version", () => {
+    expect(stepNamed("Publish to the MCP registry")).toContain(
+      `if: (${registryLegGuard}) && steps.registry.outputs.changed == 'true'`,
+    );
+  });
+
+  it("checks the exact registry version rather than trusting search results", () => {
+    const check = stepNamed("Check if version is already in the MCP registry");
+    expect(check).toContain(
+      "/v0.1/servers/$SERVER_NAME_ENCODED/versions/$LOCAL_VERSION_ENCODED",
+    );
+    expect(check).not.toContain("?search=");
+  });
+});
+
+

--- a/src/__tests__/publish-workflow.test.ts
+++ b/src/__tests__/publish-workflow.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 const workflow = readFileSync(
   new URL("../../.github/workflows/publish.yml", import.meta.url),
   "utf8",
-).replace(/\\r\\n/g, "\\n");
+).replace(/\r\n/g, "\n");
 
 function stepNamed(name: string): string {
   const marker = `      - name: ${name}\n`;

--- a/src/__tests__/publish-workflow.test.ts
+++ b/src/__tests__/publish-workflow.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 const workflow = readFileSync(
   new URL("../../.github/workflows/publish.yml", import.meta.url),
   "utf8",
-);
+).replace(/\\r\\n/g, "\\n");
 
 function stepNamed(name: string): string {
   const marker = `      - name: ${name}\n`;


### PR DESCRIPTION
Fixes #44.

## Root cause

The npm half of the publish workflow skipped when `package.json` had not changed version, but the MCP Registry half still ran. Its search endpoint also reported an older indexed version than the publish endpoint knew about, so the workflow attempted to republish `0.4.0` and received a duplicate-version 400. This reproduced in runs 31251040096 and 30763449853.

## What changed

- ordinary `package.json` pushes with an already-published npm version now skip the entire registry leg
- manual `workflow_dispatch` retains registry-only catch-up
- registry presence is checked through the official exact-version endpoint rather than search results
- 200 skips, 404 publishes, and lookup failures fall through to the authoritative publisher
- a focused workflow regression test pins all four control-flow requirements

The exact endpoint is the stable Registry API route `GET /v0.1/servers/{serverName}/versions/{version}`; both path values are URL-encoded.

## Verification

- `git diff --check`
- YAML parse
- `npm run lint`
- `npm run build`
- `npm test` — 167/167 passing
- regression test confirmed 4/4 red on current main and 4/4 green with this patch

## Residual risk

Unexpected registry lookup failures still attempt publication by design. A registry outage or future contract failure can therefore make the manual/publishing job red, but it cannot silently suppress a required release.