### PR TITLE
fix: keep Docker updates on the selected Node major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 1
+    # Production stays on the selected Node LTS line. Dependabot should refresh
+    # the pinned image digest without silently changing the runtime major.
+    ignore:
+      - dependency-name: node
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## What & why

Keep Docker image updates on the selected Node LTS major. Dependabot opened #51 to move the production image from Node 22 to pre-LTS Node 26 immediately after #50 pinned the Node 22 / Alpine 3.24 base for reproducible digest refreshes.

This ignores Docker semver-major updates for the `node` image while leaving same-major and digest updates enabled. Node major upgrades remain deliberate maintainer changes. This supersedes #51.

## How verified

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (172 tests)
- [x] `git diff --check`
- [x] Resulting Dependabot config exactly matches the independently parsed and value-asserted policy used by `substack-mcp`
