### PR TITLE
Add sheets_batchUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ A service's tool count (headers below) tracks its context cost: dropping `tasks`
 - `sheets_values_get` — Read cell values
 - `sheets_values_update` — Write cell values
 - `sheets_values_append` — Append rows
-- `sheets_batchUpdate` — Apply updates to a spreadsheet (conditional formatting, cell/border formatting, adding sheets, and more)
+- `sheets_batchUpdate` — Apply updates to a spreadsheet (conditional formatting, cell/border formatting, adding sheets, and more; delete requests are permanent)
 
 ### `calendar` (5 tools)
 - `calendar_events_list` — List events

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gws-mcp-server
 
-Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks as a curated set of 44 [Model Context Protocol](https://modelcontextprotocol.io/) tools, built on the official [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli).
+Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks as a curated set of 45 [Model Context Protocol](https://modelcontextprotocol.io/) tools, built on the official [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli).
 
 [![npm version](https://img.shields.io/npm/v/gws-mcp-server?style=flat-square)](https://www.npmjs.com/package/gws-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
@@ -102,7 +102,7 @@ npm install && npm run build
 
 ### `--read-only`
 
-`--read-only` registers **20 tools** instead of 44. Every tool that writes to Google is left unregistered, so it never appears in `tools/list` and there is nothing for an agent to call — including `gmail_drafts_create`, which is a write even though it never sends. `drive_files_download` stays, since it reads.
+`--read-only` registers **20 tools** instead of 45. Every tool that writes to Google is left unregistered, so it never appears in `tools/list` and there is nothing for an agent to call — including `gmail_drafts_create`, which is a write even though it never sends. `drive_files_download` stays, since it reads.
 
 ```bash
 gws-mcp-server --read-only
@@ -113,7 +113,7 @@ This constrains the **agent, not the credential**. The token on disk keeps whate
 
 ### Trimming context cost
 
-Every registered tool rides along in each conversation: the full registry is roughly 30 KB of `tools/list` payload (about 7.6K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
+Every registered tool rides along in each conversation: the full registry is 31,196 B of `tools/list` payload (~7.8K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
 
 ```bash
 gws-mcp-server --services calendar                       # calendar assistant: 5 tools
@@ -142,11 +142,12 @@ A service's tool count (headers below) tracks its context cost: dropping `tasks`
 - `drive_files_download` — Download file content (text inline, binary as base64 or saved to a path; Google-native files are exported to a readable format)
 - `drive_permissions_create` — Share files
 
-### `sheets` (4 tools)
+### `sheets` (5 tools)
 - `sheets_get` — Get spreadsheet metadata
 - `sheets_values_get` — Read cell values
 - `sheets_values_update` — Write cell values
 - `sheets_values_append` — Append rows
+- `sheets_batchUpdate` — Apply updates to a spreadsheet (conditional formatting, cell/border formatting, adding sheets, and more)
 
 ### `calendar` (5 tools)
 - `calendar_events_list` — List events
@@ -191,7 +192,7 @@ A service's tool count (headers below) tracks its context cost: dropping `tasks`
 
 > **Update semantics:** the `*_update` tools (calendar events, tasks, task lists) use the Google API's `patch` verb — they merge the fields you supply and leave the rest untouched. To *clear* an existing value, pass it explicitly (e.g. an empty string) rather than omitting it.
 
-**Total: 44 tools** (vs 200-400 in the old implementation)
+**Total: 45 tools** (vs 200-400 in the old implementation)
 
 ## Adding new tools
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.conorbronsdon/gws-mcp-server",
   "title": "Google Workspace MCP Server",
-  "description": "Google Workspace as 44 curated MCP tools: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks.",
+  "description": "Google Workspace as 45 curated MCP tools: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks.",
   "repository": {
     "url": "https://github.com/conorbronsdon/gws-mcp-server",
     "source": "github"

--- a/src/__tests__/annotations.e2e.test.ts
+++ b/src/__tests__/annotations.e2e.test.ts
@@ -58,7 +58,7 @@ const byName = (n: string): ListedTool => {
 
 describe("advertised annotations", () => {
   it("registers both hand-written tools alongside the registry tools", () => {
-    expect(tools.length).toBe(44);
+    expect(tools.length).toBe(45);
     expect(byName("drive_files_download")).toBeDefined();
     expect(byName("gmail_drafts_create")).toBeDefined();
   });
@@ -116,6 +116,7 @@ describe("advertised annotations", () => {
       "calendar_events_delete",
       "docs_batchUpdate",
       "drive_files_delete",
+      "sheets_batchUpdate",
       "slides_batchUpdate",
       "tasks_tasklists_delete",
       "tasks_tasks_clear",
@@ -151,8 +152,8 @@ describe("startup tool count", () => {
     // Guards against the fix being "fudge the string": the number has to come
     // from somewhere other than the registry length.
     const registry = getToolsForServices(ALL_SERVICES);
-    expect(registry.length).toBe(42);
-    expect(countRegisteredTools(registry, ALL_SERVICES)).toBe(44);
+    expect(registry.length).toBe(43);
+    expect(countRegisteredTools(registry, ALL_SERVICES)).toBe(45);
     expect(countRegisteredTools(registry, ["sheets"])).toBe(registry.length);
   });
 });
@@ -184,8 +185,8 @@ describe("--read-only", () => {
     const dropped = tools
       .filter((t) => t.annotations?.readOnlyHint !== true)
       .map((t) => t.name);
-    // 44 default - 20 read-only = 24 writes, all gone.
-    expect(dropped.length).toBe(24);
+    // 45 default - 20 read-only = 25 writes, all gone.
+    expect(dropped.length).toBe(25);
     for (const name of dropped) {
       expect(roTools.find((t) => t.name === name)).toBeUndefined();
     }
@@ -202,7 +203,7 @@ describe("--read-only", () => {
   });
 
   it("is additive — the default server is unchanged", () => {
-    expect(tools.length).toBe(44);
+    expect(tools.length).toBe(45);
     expect(tools.find((t) => t.name === "gmail_drafts_create")).toBeDefined();
     expect(tools.find((t) => t.name === "drive_files_delete")).toBeDefined();
   });
@@ -227,8 +228,8 @@ describe("idempotentHint / openWorldHint", () => {
       .filter((t) => typeof t.annotations?.openWorldHint !== "boolean")
       .map((t) => t.name);
     expect(missing).toEqual([]);
-    // All 44 reach Google Workspace, whose state changes independently of us.
-    expect(tools.filter((t) => t.annotations?.openWorldHint === true).length).toBe(44);
+    // All 45 reach Google Workspace, whose state changes independently of us.
+    expect(tools.filter((t) => t.annotations?.openWorldHint === true).length).toBe(45);
   });
 
   it("every write advertises idempotentHint, and no read does", () => {
@@ -287,6 +288,7 @@ describe("idempotentHint / openWorldHint", () => {
       "drive_files_create",
       "drive_permissions_create",
       "gmail_drafts_create",
+      "sheets_batchUpdate",
       "sheets_values_append",
       "slides_batchUpdate",
       "slides_create",
@@ -298,6 +300,7 @@ describe("idempotentHint / openWorldHint", () => {
   it("marks batchUpdate tools that can permanently delete content as destructive", () => {
     expect(byName("docs_batchUpdate").annotations?.destructiveHint).toBe(true);
     expect(byName("slides_batchUpdate").annotations?.destructiveHint).toBe(true);
+    expect(byName("sheets_batchUpdate").annotations?.destructiveHint).toBe(true);
   });
 
   it("gives the hand-registered tools all the hints the builder would", () => {
@@ -314,13 +317,13 @@ describe("idempotentHint / openWorldHint", () => {
     });
   });
 
-  it("accounts for all 44 tools", () => {
+  it("accounts for all 45 tools", () => {
     const reads = tools.filter((t) => t.annotations?.readOnlyHint === true).length;
     const idem = tools.filter((t) => t.annotations?.idempotentHint === true).length;
     const nonIdem = tools.filter((t) => t.annotations?.idempotentHint === false).length;
     expect(reads).toBe(20);
-    expect(idem + nonIdem).toBe(44 - reads);
+    expect(idem + nonIdem).toBe(45 - reads);
     expect(idem).toBe(12);
-    expect(nonIdem).toBe(12);
+    expect(nonIdem).toBe(13);
   });
 });

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -59,7 +59,7 @@ describe("tool definitions integrity", () => {
 
   it("has correct tool counts per service", () => {
     expect(SERVICE_TOOLS["drive"].length).toBe(8);
-    expect(SERVICE_TOOLS["sheets"].length).toBe(4);
+    expect(SERVICE_TOOLS["sheets"].length).toBe(5);
     expect(SERVICE_TOOLS["calendar"].length).toBe(5);
     expect(SERVICE_TOOLS["docs"].length).toBe(3);
     expect(SERVICE_TOOLS["slides"].length).toBe(5);
@@ -67,8 +67,8 @@ describe("tool definitions integrity", () => {
     expect(SERVICE_TOOLS["tasks"].length).toBe(12);
   });
 
-  it("total tool count is 42", () => {
-    expect(allTools.length).toBe(42);
+  it("total tool count is 43", () => {
+    expect(allTools.length).toBe(43);
   });
 
   it("all params have required fields", () => {
@@ -408,6 +408,7 @@ describe("tool annotation classifications", () => {
       "calendar_events_delete",
       "docs_batchUpdate",
       "slides_batchUpdate",
+      "sheets_batchUpdate",
       "tasks_tasklists_delete",
       "tasks_tasks_delete",
       "tasks_tasks_clear",
@@ -490,14 +491,14 @@ describe("tool annotation classifications", () => {
     }
   });
 
-  it("classification counts match the intended split (19 read / 7 destructive / 16 additive)", () => {
+  it("classification counts match the intended split (19 read / 8 destructive / 16 additive)", () => {
     const read = allTools.filter((t) => buildAnnotations(t).readOnlyHint === true).length;
     const destructive = allTools.filter((t) => buildAnnotations(t).destructiveHint === true).length;
     const additive = allTools.filter(
       (t) => buildAnnotations(t).readOnlyHint === false && buildAnnotations(t).destructiveHint === false,
     ).length;
     expect(read).toBe(19);
-    expect(destructive).toBe(7);
+    expect(destructive).toBe(8);
     expect(additive).toBe(16);
     expect(read + destructive + additive).toBe(allTools.length);
   });

--- a/src/services.ts
+++ b/src/services.ts
@@ -270,6 +270,21 @@ const sheetsTools: ToolDef[] = [
       { name: "values", description: "2D array of values as JSON string", type: "string", required: true },
     ],
   },
+  {
+    name: "sheets_batchUpdate",
+    description: "Apply updates to a spreadsheet (conditional formatting, cell/border formatting, adding sheets, and more).",
+    command: ["sheets", "spreadsheets", "batchUpdate"],
+    params: [
+      { name: "spreadsheetId", description: "The spreadsheet ID", type: "string", required: true },
+    ],
+    bodyParams: [
+      { name: "requests", description: "Array of update requests as JSON string", type: "string", required: true },
+    ],
+    // Mirrors docs_batchUpdate: the request union includes delete-capable
+    // requests (e.g. deleteConditionalFormatRule, deleteSheet), so the
+    // annotation describes the tool's worst-case capability, not per-call behavior.
+    destructive: true,
+  },
 ];
 
 // ── Calendar ───────────────────────────────────────────────────────────

--- a/src/services.ts
+++ b/src/services.ts
@@ -272,7 +272,7 @@ const sheetsTools: ToolDef[] = [
   },
   {
     name: "sheets_batchUpdate",
-    description: "Apply updates to a spreadsheet (conditional formatting, cell/border formatting, adding sheets, and more).",
+    description: "Apply updates to a spreadsheet (conditional formatting, cell/border formatting, adding sheets, and more). Can also permanently delete content — e.g. removing a sheet or a conditional formatting rule — with no undo via the API.",
     command: ["sheets", "spreadsheets", "batchUpdate"],
     params: [
       { name: "spreadsheetId", description: "The spreadsheet ID", type: "string", required: true },


### PR DESCRIPTION
## Summary

`gws` already fully implements `sheets.spreadsheets.batchUpdate` (conditional formatting, cell/border formatting, adding sheets, etc.) but it was never wired into the MCP tool registry — Sheets was the only service missing a generic `batchUpdate` passthrough that Docs and Slides both already have. Follows the exact existing pattern: raw request JSON via one generic tool rather than a dedicated tool per operation, `destructive: true` for the same reason as `docs_batchUpdate`/`slides_batchUpdate` (the request union includes delete-capable requests, e.g. `deleteConditionalFormatRule`/`deleteSheet`), and the deletion/permanence caveat stated directly in the tool's own description per the review feedback on #34/#35.

Verified live against a disposable spreadsheet: `batchUpdate` with an `addSheet` + `addConditionalFormatRule` request succeeded, then the test file was deleted and confirmed gone (404 on re-fetch).

## Checklist

- [x] `npm run lint` and `npm test` pass (170/170, tests mock the executor, no real `gws` calls)
- [x] New tool is narrowly scoped and maps to a single `gws` CLI command (keeps the curated contract)
- [x] No shell-injection surface: args go through `src/executor.ts`, never string-concatenated commands
- [x] README service/tool list and total count updated (44 → 45), including the measured `tools/list` payload size (31,196 B / ~7.8K tokens)