### PR TITLE
Add drive_permissions_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ A service's tool count (headers below) tracks its context cost: dropping `tasks`
 
 ## Available services & tools
 
-### `drive` (9 tools)
+### `drive` (10 tools)
 - `drive_files_list` — Search and list files
 - `drive_files_get` — Get file metadata
 - `drive_files_create` — Create files (with optional upload)
@@ -141,6 +141,7 @@ A service's tool count (headers below) tracks its context cost: dropping `tasks`
 - `drive_files_export` — Export Google Workspace files (Doc, Sheet, Slide) to other formats
 - `drive_files_download` — Download file content (text inline, binary as base64 or saved to a path; Google-native files are exported to a readable format)
 - `drive_permissions_create` — Share files
+- `drive_permissions_list` — List all permissions on a file (audit sharing state, e.g. check for public access)
 
 ### `sheets` (5 tools)
 - `sheets_get` — Get spreadsheet metadata

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gws-mcp-server
 
-Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks as a curated set of 46 [Model Context Protocol](https://modelcontextprotocol.io/) tools, built on the official [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli).
+Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks as a curated set of 47 [Model Context Protocol](https://modelcontextprotocol.io/) tools, built on the official [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli).
 
 [![npm version](https://img.shields.io/npm/v/gws-mcp-server?style=flat-square)](https://www.npmjs.com/package/gws-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
@@ -102,7 +102,7 @@ npm install && npm run build
 
 ### `--read-only`
 
-`--read-only` registers **21 tools** instead of 46. Every tool that writes to Google is left unregistered, so it never appears in `tools/list` and there is nothing for an agent to call — including `gmail_drafts_create`, which is a write even though it never sends. `drive_files_download` stays, since it reads.
+`--read-only` registers **22 tools** instead of 47. Every tool that writes to Google is left unregistered, so it never appears in `tools/list` and there is nothing for an agent to call — including `gmail_drafts_create`, which is a write even though it never sends. `drive_files_download` stays, since it reads.
 
 ```bash
 gws-mcp-server --read-only
@@ -113,7 +113,7 @@ This constrains the **agent, not the credential**. The token on disk keeps whate
 
 ### Trimming context cost
 
-Every registered tool rides along in each conversation: the full registry is roughly 31 KB of `tools/list` payload (~8.0K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
+Every registered tool rides along in each conversation: the full registry is roughly 32 KB of `tools/list` payload (~8.2K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
 
 ```bash
 gws-mcp-server --services calendar                       # calendar assistant: 6 tools
@@ -194,7 +194,7 @@ A service's tool count (headers below) tracks its context cost: dropping `tasks`
 
 > **Update semantics:** the `*_update` tools (calendar events, tasks, task lists) use the Google API's `patch` verb — they merge the fields you supply and leave the rest untouched. To *clear* an existing value, pass it explicitly (e.g. an empty string) rather than omitting it.
 
-**Total: 46 tools** (vs 200-400 in the old implementation)
+**Total: 47 tools** (vs 200-400 in the old implementation)
 
 ## Adding new tools
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.conorbronsdon/gws-mcp-server",
   "title": "Google Workspace MCP Server",
-  "description": "Google Workspace as 45 curated MCP tools: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks.",
+  "description": "Google Workspace as 47 curated MCP tools: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks.",
   "repository": {
     "url": "https://github.com/conorbronsdon/gws-mcp-server",
     "source": "github"

--- a/src/__tests__/annotations.e2e.test.ts
+++ b/src/__tests__/annotations.e2e.test.ts
@@ -58,7 +58,7 @@ const byName = (n: string): ListedTool => {
 
 describe("advertised annotations", () => {
   it("registers both hand-written tools alongside the registry tools", () => {
-    expect(tools.length).toBe(46);
+    expect(tools.length).toBe(47);
     expect(byName("drive_files_download")).toBeDefined();
     expect(byName("gmail_drafts_create")).toBeDefined();
   });
@@ -152,8 +152,8 @@ describe("startup tool count", () => {
     // Guards against the fix being "fudge the string": the number has to come
     // from somewhere other than the registry length.
     const registry = getToolsForServices(ALL_SERVICES);
-    expect(registry.length).toBe(44);
-    expect(countRegisteredTools(registry, ALL_SERVICES)).toBe(46);
+    expect(registry.length).toBe(45);
+    expect(countRegisteredTools(registry, ALL_SERVICES)).toBe(47);
     expect(countRegisteredTools(registry, ["sheets"])).toBe(registry.length);
   });
 });
@@ -171,9 +171,9 @@ describe("--read-only", () => {
     roTools = (await client.listTools()).tools as ListedTool[];
   });
 
-  it("exposes exactly the 21 read-only tools", () => {
-    expect(roTools.length).toBe(21);
-    expect(countRegisteredTools(getToolsForServices(ALL_SERVICES), ALL_SERVICES, true)).toBe(21);
+  it("exposes exactly the 22 read-only tools", () => {
+    expect(roTools.length).toBe(22);
+    expect(countRegisteredTools(getToolsForServices(ALL_SERVICES), ALL_SERVICES, true)).toBe(22);
   });
 
   it("lists no tool that advertises itself as a write", () => {
@@ -185,7 +185,7 @@ describe("--read-only", () => {
     const dropped = tools
       .filter((t) => t.annotations?.readOnlyHint !== true)
       .map((t) => t.name);
-    // 46 default - 21 read-only = 25 writes, all gone.
+    // 47 default - 22 read-only = 25 writes, all gone.
     expect(dropped.length).toBe(25);
     for (const name of dropped) {
       expect(roTools.find((t) => t.name === name)).toBeUndefined();
@@ -203,7 +203,7 @@ describe("--read-only", () => {
   });
 
   it("is additive — the default server is unchanged", () => {
-    expect(tools.length).toBe(46);
+    expect(tools.length).toBe(47);
     expect(tools.find((t) => t.name === "gmail_drafts_create")).toBeDefined();
     expect(tools.find((t) => t.name === "drive_files_delete")).toBeDefined();
   });
@@ -228,8 +228,8 @@ describe("idempotentHint / openWorldHint", () => {
       .filter((t) => typeof t.annotations?.openWorldHint !== "boolean")
       .map((t) => t.name);
     expect(missing).toEqual([]);
-    // All 46 reach Google Workspace, whose state changes independently of us.
-    expect(tools.filter((t) => t.annotations?.openWorldHint === true).length).toBe(46);
+    // All 47 reach Google Workspace, whose state changes independently of us.
+    expect(tools.filter((t) => t.annotations?.openWorldHint === true).length).toBe(47);
   });
 
   it("every write advertises idempotentHint, and no read does", () => {
@@ -317,12 +317,12 @@ describe("idempotentHint / openWorldHint", () => {
     });
   });
 
-  it("accounts for all 46 tools", () => {
+  it("accounts for all 47 tools", () => {
     const reads = tools.filter((t) => t.annotations?.readOnlyHint === true).length;
     const idem = tools.filter((t) => t.annotations?.idempotentHint === true).length;
     const nonIdem = tools.filter((t) => t.annotations?.idempotentHint === false).length;
-    expect(reads).toBe(21);
-    expect(idem + nonIdem).toBe(46 - reads);
+    expect(reads).toBe(22);
+    expect(idem + nonIdem).toBe(47 - reads);
     expect(idem).toBe(12);
     expect(nonIdem).toBe(13);
   });

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -309,6 +309,61 @@ describe("calendar attendees + sendUpdates", () => {
   });
 });
 
+// ── drive_permissions_list: shared drives + grantee identification ───────
+// Two silent-failure modes, both invisible unless something asserts on the
+// generated --params. Without defaultParams the shared-drive flag never
+// reaches the CLI, so listing permissions fails on exactly the shared-drive
+// files the other drive tools can already read. Without a declared `fields`
+// param buildArgs discards the caller's field mask, and Drive's default
+// permissions response carries only id/type/kind/role — an audit can see
+// that a file is shared but not with whom, which is the tool's whole point.
+
+describe("drive_permissions_list (shared drives + grantee fields)", () => {
+  const tool = SERVICE_TOOLS["drive"].find((t) => t.name === "drive_permissions_list")!;
+
+  it("sends supportsAllDrives without the caller asking, like drive_files_get", () => {
+    const args = buildArgs(tool, { fileId: "file123" });
+    const paramsIdx = args.indexOf("--params");
+    expect(paramsIdx).toBeGreaterThan(-1);
+    // Compare against the same escaping buildArgs applies, so this holds on
+    // Windows (cmd-escaped) as well as Linux/macOS (escapeJsonArg is a no-op).
+    expect(args[paramsIdx + 1]).toBe(
+      escapeJsonArg(JSON.stringify({ supportsAllDrives: true, fileId: "file123" })),
+    );
+  });
+
+  it("declares fields as an optional param — undeclared params are discarded", () => {
+    const fields = tool.params.find((p) => p.name === "fields");
+    expect(fields, "drive_permissions_list should declare 'fields'").toBeDefined();
+    expect(fields!.required).toBe(false);
+    expect(fields!.type).toBe("string");
+  });
+
+  it("passes a caller's field mask through, so grantees can be identified", () => {
+    const fields = "nextPageToken,permissions(id,type,role,emailAddress,domain)";
+    const args = buildArgs(tool, { fileId: "file123", fields });
+    const paramsIdx = args.indexOf("--params");
+    expect(args[paramsIdx + 1]).toBe(
+      escapeJsonArg(JSON.stringify({ supportsAllDrives: true, fileId: "file123", fields })),
+    );
+  });
+
+  it("keeps pagination working alongside the injected default", () => {
+    const args = buildArgs(tool, { fileId: "file123", pageSize: 100, pageToken: "tok" });
+    const paramsIdx = args.indexOf("--params");
+    expect(args[paramsIdx + 1]).toBe(
+      escapeJsonArg(
+        JSON.stringify({
+          supportsAllDrives: true,
+          fileId: "file123",
+          pageSize: 100,
+          pageToken: "tok",
+        }),
+      ),
+    );
+  });
+});
+
 // ── Tool annotations (issue #5) ──────────────────────────────────────────
 
 describe("buildAnnotations mapping", () => {

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -67,8 +67,8 @@ describe("tool definitions integrity", () => {
     expect(SERVICE_TOOLS["tasks"].length).toBe(12);
   });
 
-  it("total tool count is 44", () => {
-    expect(allTools.length).toBe(44);
+  it("total tool count is 45", () => {
+    expect(allTools.length).toBe(45);
   });
 
   it("all params have required fields", () => {
@@ -491,13 +491,13 @@ describe("tool annotation classifications", () => {
     }
   });
 
-  it("classification counts match the intended split (20 read / 8 destructive / 16 additive)", () => {
+  it("classification counts match the intended split (21 read / 8 destructive / 16 additive)", () => {
     const read = allTools.filter((t) => buildAnnotations(t).readOnlyHint === true).length;
     const destructive = allTools.filter((t) => buildAnnotations(t).destructiveHint === true).length;
     const additive = allTools.filter(
       (t) => buildAnnotations(t).readOnlyHint === false && buildAnnotations(t).destructiveHint === false,
     ).length;
-    expect(read).toBe(20);
+    expect(read).toBe(21);
     expect(destructive).toBe(8);
     expect(additive).toBe(16);
     expect(read + destructive + additive).toBe(allTools.length);

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -58,7 +58,7 @@ describe("tool definitions integrity", () => {
   });
 
   it("has correct tool counts per service", () => {
-    expect(SERVICE_TOOLS["drive"].length).toBe(8);
+    expect(SERVICE_TOOLS["drive"].length).toBe(9);
     expect(SERVICE_TOOLS["sheets"].length).toBe(5);
     expect(SERVICE_TOOLS["calendar"].length).toBe(6);
     expect(SERVICE_TOOLS["docs"].length).toBe(3);
@@ -422,7 +422,7 @@ describe("tool annotation classifications", () => {
 
   it("named read tools carry readOnlyHint:true", () => {
     const expectReadOnly = [
-      "drive_files_list", "drive_files_get", "drive_files_export",
+      "drive_files_list", "drive_files_get", "drive_files_export", "drive_permissions_list",
       "sheets_get", "sheets_values_get",
       "calendar_events_list", "calendar_events_get", "calendar_freebusy_query",
       "docs_get",

--- a/src/services.ts
+++ b/src/services.ts
@@ -216,6 +216,17 @@ const driveTools: ToolDef[] = [
       { name: "emailAddress", description: "Email of user/group (required for user/group type)", type: "string", required: false },
     ],
   },
+  {
+    name: "drive_permissions_list",
+    description: "List all permissions on a file. Use to audit sharing state — e.g. a permission with type \"anyone\" means the file is publicly accessible; there is no separate is-public field.",
+    command: ["drive", "permissions", "list"],
+    params: [
+      { name: "fileId", description: "The file to list permissions for", type: "string", required: true },
+      { name: "pageSize", description: "Max permissions to return", type: "number", required: false },
+      { name: "pageToken", description: "Page token from a previous call", type: "string", required: false },
+    ],
+    readOnly: true,
+  },
 ];
 
 // ── Sheets ──────────────────────────────────────────────────────────────

--- a/src/services.ts
+++ b/src/services.ts
@@ -218,13 +218,15 @@ const driveTools: ToolDef[] = [
   },
   {
     name: "drive_permissions_list",
-    description: "List all permissions on a file. Use to audit sharing state — e.g. a permission with type \"anyone\" means the file is publicly accessible; there is no separate is-public field.",
+    description: "List all permissions on a file. Use to audit sharing state — e.g. a permission with type \"anyone\" means the file is publicly accessible; there is no separate is-public field. Pass fields (e.g. \"permissions(id,type,role,emailAddress,domain)\") to identify grantees — the default response omits emailAddress/domain.",
     command: ["drive", "permissions", "list"],
     params: [
       { name: "fileId", description: "The file to list permissions for", type: "string", required: true },
       { name: "pageSize", description: "Max permissions to return", type: "number", required: false },
       { name: "pageToken", description: "Page token from a previous call", type: "string", required: false },
+      { name: "fields", description: "Fields to include (e.g. \"permissions(id,type,role,emailAddress,domain)\")", type: "string", required: false },
     ],
+    defaultParams: DRIVE_SHARED_DEFAULTS_NO_INCLUDE,
     readOnly: true,
   },
 ];


### PR DESCRIPTION
## Summary

`gws` already fully implements `drive.permissions.list` but it was never wired into the MCP tool registry — `drive_permissions_create` exists for sharing, but there was no way to read back what's currently shared. Also documents the correct way to check whether a file is public: the Drive API has no discrete is-public field, you list permissions and look for `type: "anyone"`. That's stated directly in the tool's description rather than adding a separate, narrower tool for just that one case.

Verified live: created a disposable file, listed its permissions (got back the owner permission), then deleted the file and confirmed it's gone (404 on re-fetch).

## Checklist

- [x] `npm run lint` and `npm test` pass (170/170, tests mock the executor, no real `gws` calls)
- [x] New tool is narrowly scoped and maps to a single `gws` CLI command (keeps the curated contract)
- [x] No shell-injection surface: args go through `src/executor.ts`, never string-concatenated commands
- [x] README service/tool list and total count updated (44 → 45, drive 9 → 10), including the measured `tools/list` payload size (31,277 B / ~7.8K tokens)