### PR TITLE
docs: avoid stale exact registry size

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This constrains the **agent, not the credential**. The token on disk keeps whate
 
 ### Trimming context cost
 
-Every registered tool rides along in each conversation: the full registry is 31,196 B of `tools/list` payload (~7.8K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
+Every registered tool rides along in each conversation: the full registry is roughly 31 KB of `tools/list` payload (~7.8K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
 
 ```bash
 gws-mcp-server --services calendar                       # calendar assistant: 5 tools


### PR DESCRIPTION
## Summary

- Replace the exact `tools/list` byte count with a stable approximate size
- Preserve the useful context-cost guidance without requiring every tool-description edit to remeasure the registry

Follow-up to #54, whose final description update made the previously measured exact count stale.