### PR TITLE
Constrain sendUpdates and correct the idempotent hint on calendar_events_update

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, Slides, an
 
 ## Why?
 
-The `gws` CLI had a built-in MCP server that was [removed in v0.8.0](https://github.com/googleworkspace/cli/pull/275) because it exposed 200-400 tools — causing context window bloat in MCP clients. This server takes a curated approach: you choose which Google services to expose, and only a focused set of high-value, narrowly scoped operations are registered as tools. Every tool declares all four MCP annotation hints — `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` — so clients can reason about side effects, know which writes are safe to retry, and surface clearer consent prompts. This is the permissions leg of trust infrastructure for agents: a deliberately narrow tool surface, side effects declared on every tool, and no send tool at all.
+The `gws` CLI had a built-in MCP server that was [removed in v0.8.0](https://github.com/googleworkspace/cli/pull/275) because it exposed 200-400 tools — causing context window bloat in MCP clients. This server takes a curated approach: you choose which Google services to expose, and only a focused set of high-value, narrowly scoped operations are registered as tools. Every tool declares all four MCP annotation hints — `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` — so clients can reason about side effects, know which writes are safe to retry, and surface clearer consent prompts. This is the permissions leg of trust infrastructure for agents: a deliberately narrow tool surface, side effects declared on every tool, and no freestanding send tool — the only outbound email an agent can trigger is calendar invite/update notifications, opt-in via `sendUpdates` and off by default.
 
 ## Prerequisites
 
@@ -28,7 +28,7 @@ The `gws` CLI had a built-in MCP server that was [removed in v0.8.0](https://git
 
 ### Grant fewer scopes than the default
 
-This server exposes **no send tool** — the closest thing is `gmail_drafts_create`, which explicitly does not send. The token `gws auth login` mints is broader than that.
+This server exposes **no freestanding send tool** — `gmail_drafts_create` explicitly does not send, and the only outbound email an agent can trigger is calendar invite/update notifications via `sendUpdates`, which is enum-validated and defaults to `none`. The token `gws auth login` mints is broader than that.
 
 `gws auth login` opens a scope picker listing **nine** scopes. The default grant is **seven**: full read-write `drive`, `spreadsheets`, `gmail.modify` (Google documents it as "Read, compose, and send emails"), `calendar`, `documents`, `presentations`, and `tasks` — the same seven you get running non-interactively as `DEFAULT_SCOPES`.
 

--- a/src/__tests__/annotations.e2e.test.ts
+++ b/src/__tests__/annotations.e2e.test.ts
@@ -258,7 +258,6 @@ describe("idempotentHint / openWorldHint", () => {
       .sort();
     expect(idempotent).toEqual([
       "calendar_events_delete",
-      "calendar_events_update",
       "drive_files_delete",
       "drive_files_update",
       "gmail_threads_modify",
@@ -282,6 +281,9 @@ describe("idempotentHint / openWorldHint", () => {
       .sort();
     expect(notIdempotent).toEqual([
       "calendar_events_insert",
+      // Update joined this list when sendUpdates landed: a retry with
+      // "all"/"externalOnly" re-emails every attendee, so repeats are not free.
+      "calendar_events_update",
       "docs_batchUpdate",
       "docs_create",
       "drive_files_copy",
@@ -323,7 +325,7 @@ describe("idempotentHint / openWorldHint", () => {
     const nonIdem = tools.filter((t) => t.annotations?.idempotentHint === false).length;
     expect(reads).toBe(22);
     expect(idem + nonIdem).toBe(47 - reads);
-    expect(idem).toBe(12);
-    expect(nonIdem).toBe(13);
+    expect(idem).toBe(11);
+    expect(nonIdem).toBe(14);
   });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -25,6 +25,26 @@ describe("buildZodSchema", () => {
     expect(bad.success).toBe(false);
   });
 
+  it("maps enum-constrained string params to z.enum — out-of-set values never reach the wire", () => {
+    const tool: ToolDef = {
+      name: "test",
+      description: "test",
+      command: ["test"],
+      params: [
+        { name: "sendUpdates", description: "who gets email", type: "string", required: false, enum: ["all", "externalOnly", "none"] },
+      ],
+    };
+    const schema = buildZodSchema(tool);
+    for (const ok of ["all", "externalOnly", "none"]) {
+      expect(schema.sendUpdates.safeParse(ok).success).toBe(true);
+    }
+    // Must-fail leg: values outside the set are rejected at the boundary.
+    expect(schema.sendUpdates.safeParse("EVERYONE_LOL").success).toBe(false);
+    expect(schema.sendUpdates.safeParse("al").success).toBe(false);
+    // Optional still holds: omitting the param entirely stays valid.
+    expect(schema.sendUpdates.safeParse(undefined).success).toBe(true);
+  });
+
   it("maps number params to z.number()", () => {
     const tool: ToolDef = {
       name: "test",

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { getToolsForServices, SERVICE_TOOLS, ALL_SERVICES, buildAnnotations, type ToolDef } from "../services.js";
 import { buildArgs, escapeJsonArg } from "../executor.js";
+import { buildZodSchema } from "../index.js";
 
 describe("getToolsForServices", () => {
   it("returns tools for requested services", () => {
@@ -294,6 +295,31 @@ describe("calendar attendees + sendUpdates", () => {
       escapeJsonArg(JSON.stringify({ calendarId: "primary", eventId: "evt123", sendUpdates: "all" }))
     );
     expect(args[jsonIdx + 1]).toBe(escapeJsonArg(JSON.stringify({ attendees: [{ email: "a@x.com" }] })));
+  });
+
+  it("both tools constrain sendUpdates to the closed set Google accepts", () => {
+    // Pins the real tools, not just buildZodSchema's enum branch. Without this
+    // the enum could be dropped from either definition and index.test.ts would
+    // still pass on its synthetic tool.
+    for (const tool of [insertTool, updateTool]) {
+      const sendUpdates = tool.params.find((p) => p.name === "sendUpdates")!;
+      expect(sendUpdates.enum, `${tool.name} should constrain 'sendUpdates'`).toEqual([
+        "all",
+        "externalOnly",
+        "none",
+      ]);
+      const schema = buildZodSchema(tool);
+      expect(schema.sendUpdates.safeParse("all").success).toBe(true);
+      expect(schema.sendUpdates.safeParse("everyone").success).toBe(false);
+    }
+  });
+
+  it("update is not marked idempotent — a retry with sendUpdates re-emails attendees", () => {
+    // The tool patches, so the event state is idempotent, but the notification
+    // is not: "all"/"externalOnly" sends mail on every call. A client reading
+    // idempotentHint as permission to retry would mail attendees twice.
+    expect(updateTool.idempotent).toBeUndefined();
+    expect(buildAnnotations(updateTool).idempotentHint).toBe(false);
   });
 
   it("omitting attendees/sendUpdates keeps existing insert/update calls unchanged", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,9 @@ export function buildZodSchema(tool: ToolDef): Record<string, z.ZodTypeAny> {
         field = z.boolean().describe(p.description);
         break;
       default:
-        field = z.string().describe(p.description);
+        field = p.enum
+          ? z.enum(p.enum as [string, ...string[]]).describe(p.description)
+          : z.string().describe(p.description);
     }
 
     if (!p.required) {

--- a/src/services.ts
+++ b/src/services.ts
@@ -102,6 +102,9 @@ export interface ParamDef {
   description: string;
   type: "string" | "number" | "boolean";
   required: boolean;
+  /** Closed set of accepted values (string params only). Enforced at the tool
+   *  boundary via z.enum, so an out-of-set value never reaches the wire. */
+  enum?: string[];
 }
 
 // ── Drive ──────────────────────────────────────────────────────────────
@@ -334,7 +337,7 @@ const calendarTools: ToolDef[] = [
     command: ["calendar", "events", "insert"],
     params: [
       { name: "calendarId", description: "Calendar ID", type: "string", required: true },
-      { name: "sendUpdates", description: "Sends invitation email to attendees when set: \"all\", \"externalOnly\", or \"none\" (default: none — no email, though the event may still appear on an attendee's calendar depending on their settings)", type: "string", required: false },
+      { name: "sendUpdates", description: "Sends invitation email to attendees when set: \"all\", \"externalOnly\", or \"none\" (default: none — no email, though the event may still appear on an attendee's calendar depending on their settings)", type: "string", required: false, enum: ["all", "externalOnly", "none"] },
     ],
     bodyParams: [
       { name: "summary", description: "Event title", type: "string", required: true },
@@ -352,7 +355,7 @@ const calendarTools: ToolDef[] = [
     params: [
       { name: "calendarId", description: "Calendar ID", type: "string", required: true },
       { name: "eventId", description: "Event ID to update", type: "string", required: true },
-      { name: "sendUpdates", description: "Sends update email to attendees when set: \"all\", \"externalOnly\", or \"none\" (default: none — no email). With \"all\" or \"externalOnly\", attendees removed by this update receive a cancellation email", type: "string", required: false },
+      { name: "sendUpdates", description: "Sends update email to attendees when set: \"all\", \"externalOnly\", or \"none\" (default: none — no email). With \"all\" or \"externalOnly\", attendees removed by this update receive a cancellation email", type: "string", required: false, enum: ["all", "externalOnly", "none"] },
     ],
     bodyParams: [
       { name: "summary", description: "Event title", type: "string", required: false },
@@ -361,7 +364,8 @@ const calendarTools: ToolDef[] = [
       { name: "description", description: "Event description", type: "string", required: false },
       { name: "attendees", description: "REPLACES the full attendee list — Google's patch overwrites array fields, so include everyone who should remain; anyone omitted is uninvited. JSON array as string, e.g. '[{\"email\":\"a@x.com\"},{\"email\":\"b@x.com\",\"optional\":true}]'", type: "string", required: false },
     ],
-    idempotent: true,
+    // Not marked idempotent since sendUpdates landed: with "all"/"externalOnly",
+    // every retry re-emails all attendees — an additional effect per call.
   },
   {
     name: "calendar_events_delete",


### PR DESCRIPTION
## Summary

Three follow-ups that were written for #35 and never landed. The patch was authored on Aug 7, #35 merged on Aug 8 from the contributor's head, and the patch was not on that branch. It has sat on `claude/pr35-verify` since, which is now 20-plus commits behind main, so this is a port onto current main rather than a merge of that branch.

**`calendar_events_update` was marked idempotent and is not.** The tool patches, so the event state is idempotent. The notification is not: with `sendUpdates` set to `all` or `externalOnly`, every call emails the attendee list, and an attendee dropped by the update gets a cancellation. A client that reads `idempotentHint` as permission to retry mails everyone twice. The hint is static per tool, so it has to describe the worst case, which is why `calendar_events_insert` was already false.

**`sendUpdates` was an unconstrained string.** Google accepts exactly `all`, `externalOnly`, and `none`. Anything else made a round trip to Google before being rejected. `ParamDef` now carries an optional `enum`, `buildZodSchema` maps enum-constrained string params to `z.enum`, and both calendar tools declare the set. Out-of-set values are rejected at the tool boundary.

**The README contradicted itself on the send-tool claim.** Line 22 said "no send tool at all" and line 31 said "no send tool", while line 246 already said "no freestanding send tool". Calendar invitations are outbound email an agent can trigger, so the first two now match line 246 and name the exception.

## Verification

- `npm run lint` and `npm run build` clean; 179/179 tests pass.
- The new assertions pin the real tools, not just the mechanism, which was the gap called out in #56. Mutation-checked: removing the enum from the tool definitions fails 1 test, restoring `idempotent: true` fails 4.
- Annotation counts updated where the flip moves one tool: read-only stays 22 of 47, idempotent goes 12 to 11, non-idempotent 13 to 14.
- No live Google API calls.

## Note

This supersedes the stale `claude/pr35-verify` branch, which can be deleted once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTYpLnZrstoT9rS8JANEdG