### PR TITLE
Add drive_permissions_update and drive_permissions_delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gws-mcp-server
 
-Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks as a curated set of 47 [Model Context Protocol](https://modelcontextprotocol.io/) tools, built on the official [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli).
+Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks as a curated set of 49 [Model Context Protocol](https://modelcontextprotocol.io/) tools, built on the official [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli).
 
 [![npm version](https://img.shields.io/npm/v/gws-mcp-server?style=flat-square)](https://www.npmjs.com/package/gws-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
@@ -102,7 +102,7 @@ npm install && npm run build
 
 ### `--read-only`
 
-`--read-only` registers **22 tools** instead of 47. Every tool that writes to Google is left unregistered, so it never appears in `tools/list` and there is nothing for an agent to call — including `gmail_drafts_create`, which is a write even though it never sends. `drive_files_download` stays, since it reads.
+`--read-only` registers **22 tools** instead of 49. Every tool that writes to Google is left unregistered, so it never appears in `tools/list` and there is nothing for an agent to call — including `gmail_drafts_create`, which is a write even though it never sends. `drive_files_download` stays, since it reads.
 
 ```bash
 gws-mcp-server --read-only
@@ -113,7 +113,7 @@ This constrains the **agent, not the credential**. The token on disk keeps whate
 
 ### Trimming context cost
 
-Every registered tool rides along in each conversation: the full registry is roughly 32 KB of `tools/list` payload (~8.2K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
+Every registered tool rides along in each conversation: the full registry is roughly 34 KB of `tools/list` payload (~8.7K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
 
 ```bash
 gws-mcp-server --services calendar                       # calendar assistant: 6 tools
@@ -131,7 +131,7 @@ A service's tool count (headers below) tracks its context cost: dropping `tasks`
 
 ## Available services & tools
 
-### `drive` (10 tools)
+### `drive` (12 tools)
 - `drive_files_list` — Search and list files
 - `drive_files_get` — Get file metadata
 - `drive_files_create` — Create files (with optional upload)
@@ -142,6 +142,8 @@ A service's tool count (headers below) tracks its context cost: dropping `tasks`
 - `drive_files_download` — Download file content (text inline, binary as base64 or saved to a path; Google-native files are exported to a readable format)
 - `drive_permissions_create` — Share files
 - `drive_permissions_list` — List all permissions on a file (audit sharing state, e.g. check for public access)
+- `drive_permissions_update` — Change an existing permission's role (e.g. reader to writer)
+- `drive_permissions_delete` — Revoke a permission from a file
 
 ### `sheets` (5 tools)
 - `sheets_get` — Get spreadsheet metadata
@@ -194,7 +196,7 @@ A service's tool count (headers below) tracks its context cost: dropping `tasks`
 
 > **Update semantics:** the `*_update` tools (calendar events, tasks, task lists) use the Google API's `patch` verb — they merge the fields you supply and leave the rest untouched. To *clear* an existing value, pass it explicitly (e.g. an empty string) rather than omitting it.
 
-**Total: 47 tools** (vs 200-400 in the old implementation)
+**Total: 49 tools** (vs 200-400 in the old implementation)
 
 ## Adding new tools
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ A service's tool count (headers below) tracks its context cost: dropping `tasks`
 - `drive_files_download` — Download file content (text inline, binary as base64 or saved to a path; Google-native files are exported to a readable format)
 - `drive_permissions_create` — Share files
 - `drive_permissions_list` — List all permissions on a file (audit sharing state, e.g. check for public access)
-- `drive_permissions_update` — Change an existing permission's role (e.g. reader to writer)
+- `drive_permissions_update` — Change an existing permission's role (e.g. reader to writer); downgrades remove capabilities. Ownership transfers are not supported.
 - `drive_permissions_delete` — Revoke a permission from a file
 
 ### `sheets` (5 tools)

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.conorbronsdon/gws-mcp-server",
   "title": "Google Workspace MCP Server",
-  "description": "Google Workspace as 47 curated MCP tools: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks.",
+  "description": "Google Workspace as 49 curated MCP tools: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks.",
   "repository": {
     "url": "https://github.com/conorbronsdon/gws-mcp-server",
     "source": "github"

--- a/src/__tests__/annotations.e2e.test.ts
+++ b/src/__tests__/annotations.e2e.test.ts
@@ -58,7 +58,7 @@ const byName = (n: string): ListedTool => {
 
 describe("advertised annotations", () => {
   it("registers both hand-written tools alongside the registry tools", () => {
-    expect(tools.length).toBe(47);
+    expect(tools.length).toBe(49);
     expect(byName("drive_files_download")).toBeDefined();
     expect(byName("gmail_drafts_create")).toBeDefined();
   });
@@ -116,6 +116,7 @@ describe("advertised annotations", () => {
       "calendar_events_delete",
       "docs_batchUpdate",
       "drive_files_delete",
+      "drive_permissions_delete",
       "sheets_batchUpdate",
       "slides_batchUpdate",
       "tasks_tasklists_delete",
@@ -152,8 +153,8 @@ describe("startup tool count", () => {
     // Guards against the fix being "fudge the string": the number has to come
     // from somewhere other than the registry length.
     const registry = getToolsForServices(ALL_SERVICES);
-    expect(registry.length).toBe(45);
-    expect(countRegisteredTools(registry, ALL_SERVICES)).toBe(47);
+    expect(registry.length).toBe(47);
+    expect(countRegisteredTools(registry, ALL_SERVICES)).toBe(49);
     expect(countRegisteredTools(registry, ["sheets"])).toBe(registry.length);
   });
 });
@@ -185,8 +186,8 @@ describe("--read-only", () => {
     const dropped = tools
       .filter((t) => t.annotations?.readOnlyHint !== true)
       .map((t) => t.name);
-    // 47 default - 22 read-only = 25 writes, all gone.
-    expect(dropped.length).toBe(25);
+    // 49 default - 22 read-only = 27 writes, all gone.
+    expect(dropped.length).toBe(27);
     for (const name of dropped) {
       expect(roTools.find((t) => t.name === name)).toBeUndefined();
     }
@@ -203,7 +204,7 @@ describe("--read-only", () => {
   });
 
   it("is additive — the default server is unchanged", () => {
-    expect(tools.length).toBe(47);
+    expect(tools.length).toBe(49);
     expect(tools.find((t) => t.name === "gmail_drafts_create")).toBeDefined();
     expect(tools.find((t) => t.name === "drive_files_delete")).toBeDefined();
   });
@@ -228,8 +229,8 @@ describe("idempotentHint / openWorldHint", () => {
       .filter((t) => typeof t.annotations?.openWorldHint !== "boolean")
       .map((t) => t.name);
     expect(missing).toEqual([]);
-    // All 47 reach Google Workspace, whose state changes independently of us.
-    expect(tools.filter((t) => t.annotations?.openWorldHint === true).length).toBe(47);
+    // All 49 reach Google Workspace, whose state changes independently of us.
+    expect(tools.filter((t) => t.annotations?.openWorldHint === true).length).toBe(49);
   });
 
   it("every write advertises idempotentHint, and no read does", () => {
@@ -260,6 +261,8 @@ describe("idempotentHint / openWorldHint", () => {
       "calendar_events_delete",
       "drive_files_delete",
       "drive_files_update",
+      "drive_permissions_delete",
+      "drive_permissions_update",
       "gmail_threads_modify",
       "sheets_values_update",
       "tasks_tasklists_delete",
@@ -319,13 +322,13 @@ describe("idempotentHint / openWorldHint", () => {
     });
   });
 
-  it("accounts for all 47 tools", () => {
+  it("accounts for all 49 tools", () => {
     const reads = tools.filter((t) => t.annotations?.readOnlyHint === true).length;
     const idem = tools.filter((t) => t.annotations?.idempotentHint === true).length;
     const nonIdem = tools.filter((t) => t.annotations?.idempotentHint === false).length;
     expect(reads).toBe(22);
-    expect(idem + nonIdem).toBe(47 - reads);
-    expect(idem).toBe(11);
+    expect(idem + nonIdem).toBe(49 - reads);
+    expect(idem).toBe(13);
     expect(nonIdem).toBe(14);
   });
 });

--- a/src/__tests__/annotations.e2e.test.ts
+++ b/src/__tests__/annotations.e2e.test.ts
@@ -105,7 +105,7 @@ describe("advertised annotations", () => {
     expect(SERVER_VERSION).toBe(pkg.version);
   });
 
-  it("advertises every tool capable of irreversible removal as destructive", () => {
+  it("advertises tools that remove data or capabilities as destructive", () => {
     // tasks_tasks_clear is in this list and is not a *_delete: it permanently
     // removes completed tasks from a list, so it belongs here.
     const destructive = tools
@@ -117,6 +117,7 @@ describe("advertised annotations", () => {
       "docs_batchUpdate",
       "drive_files_delete",
       "drive_permissions_delete",
+      "drive_permissions_update",
       "sheets_batchUpdate",
       "slides_batchUpdate",
       "tasks_tasklists_delete",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -3,9 +3,21 @@ import { z } from "zod";
 import { isAbsolute } from "node:path";
 import { writeFileSync, existsSync, unlinkSync } from "node:fs";
 import { buildZodSchema, makeTmpFileName } from "../index.js";
-import type { ToolDef } from "../services.js";
+import { SERVICE_TOOLS, type ToolDef } from "../services.js";
 
 describe("buildZodSchema", () => {
+  it("rejects unsupported ownership transfers while accepting non-owner permission roles", () => {
+    const tool = SERVICE_TOOLS.drive.find((t) => t.name === "drive_permissions_update")!;
+    const schema = z.object(buildZodSchema(tool));
+    const args = { fileId: "file123", permissionId: "perm456" };
+    for (const role of ["owner", "writter", "", undefined]) {
+      expect(schema.safeParse({ ...args, role }).success, String(role)).toBe(false);
+    }
+    for (const role of ["organizer", "fileOrganizer", "writer", "commenter", "reader"]) {
+      expect(schema.parse({ ...args, role })).toEqual({ ...args, role });
+    }
+  });
+
   it("maps string params to z.string()", () => {
     const tool: ToolDef = {
       name: "test",

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -59,7 +59,7 @@ describe("tool definitions integrity", () => {
   });
 
   it("has correct tool counts per service", () => {
-    expect(SERVICE_TOOLS["drive"].length).toBe(9);
+    expect(SERVICE_TOOLS["drive"].length).toBe(11);
     expect(SERVICE_TOOLS["sheets"].length).toBe(5);
     expect(SERVICE_TOOLS["calendar"].length).toBe(6);
     expect(SERVICE_TOOLS["docs"].length).toBe(3);
@@ -68,8 +68,8 @@ describe("tool definitions integrity", () => {
     expect(SERVICE_TOOLS["tasks"].length).toBe(12);
   });
 
-  it("total tool count is 45", () => {
-    expect(allTools.length).toBe(45);
+  it("total tool count is 47", () => {
+    expect(allTools.length).toBe(47);
   });
 
   it("all params have required fields", () => {
@@ -390,6 +390,72 @@ describe("drive_permissions_list (shared drives + grantee fields)", () => {
   });
 });
 
+// ── drive_permissions_update/delete: shared drives ────────────────────────
+// Same silent-failure mode #56 fixed on drive_permissions_list: without
+// defaultParams, supportsAllDrives never reaches the CLI, so these two tools
+// would fail on exactly the shared-drive files the other drive tools already
+// handle. Asserted directly here instead of relying on generic buildArgs
+// coverage, since nothing else pins that *this* tool carries the default.
+
+describe("drive_permissions_update (shared drives)", () => {
+  const tool = SERVICE_TOOLS["drive"].find((t) => t.name === "drive_permissions_update")!;
+
+  it("sends supportsAllDrives without the caller asking, like drive_permissions_list", () => {
+    const args = buildArgs(tool, { fileId: "file123", permissionId: "perm456", role: "writer" });
+    const paramsIdx = args.indexOf("--params");
+    expect(paramsIdx).toBeGreaterThan(-1);
+    // Compare against the same escaping buildArgs applies, so this holds on
+    // Windows (cmd-escaped) as well as Linux/macOS (escapeJsonArg is a no-op).
+    expect(args[paramsIdx + 1]).toBe(
+      escapeJsonArg(JSON.stringify({ supportsAllDrives: true, fileId: "file123", permissionId: "perm456" })),
+    );
+    const jsonIdx = args.indexOf("--json");
+    expect(args[jsonIdx + 1]).toBe(escapeJsonArg(JSON.stringify({ role: "writer" })));
+  });
+
+  it("declares fields as an optional param — undeclared params are discarded", () => {
+    const fields = tool.params.find((p) => p.name === "fields");
+    expect(fields, "drive_permissions_update should declare 'fields'").toBeDefined();
+    expect(fields!.required).toBe(false);
+    expect(fields!.type).toBe("string");
+  });
+
+  it("passes a caller's field mask through alongside the injected default", () => {
+    const args = buildArgs(tool, {
+      fileId: "file123",
+      permissionId: "perm456",
+      fields: "id,role,emailAddress",
+      role: "reader",
+    });
+    const paramsIdx = args.indexOf("--params");
+    expect(args[paramsIdx + 1]).toBe(
+      escapeJsonArg(
+        JSON.stringify({
+          supportsAllDrives: true,
+          fileId: "file123",
+          permissionId: "perm456",
+          fields: "id,role,emailAddress",
+        }),
+      ),
+    );
+  });
+});
+
+describe("drive_permissions_delete (shared drives)", () => {
+  const tool = SERVICE_TOOLS["drive"].find((t) => t.name === "drive_permissions_delete")!;
+
+  it("sends supportsAllDrives without the caller asking, like drive_permissions_list", () => {
+    const args = buildArgs(tool, { fileId: "file123", permissionId: "perm456" });
+    const paramsIdx = args.indexOf("--params");
+    expect(paramsIdx).toBeGreaterThan(-1);
+    expect(args[paramsIdx + 1]).toBe(
+      escapeJsonArg(JSON.stringify({ supportsAllDrives: true, fileId: "file123", permissionId: "perm456" })),
+    );
+    // Delete has no request body — nothing should be sent via --json.
+    expect(args.indexOf("--json")).toBe(-1);
+  });
+});
+
 // ── Tool annotations (issue #5) ──────────────────────────────────────────
 
 describe("buildAnnotations mapping", () => {
@@ -490,6 +556,7 @@ describe("tool annotation classifications", () => {
       "docs_batchUpdate",
       "slides_batchUpdate",
       "sheets_batchUpdate",
+      "drive_permissions_delete",
       "tasks_tasklists_delete",
       "tasks_tasks_delete",
       "tasks_tasks_clear",
@@ -520,7 +587,7 @@ describe("tool annotation classifications", () => {
 
   it("additive writes are readOnlyHint:false with an explicit destructiveHint:false", () => {
     const expectAdditive = [
-      "drive_files_create", "drive_files_copy", "drive_files_update", "drive_permissions_create",
+      "drive_files_create", "drive_files_copy", "drive_files_update", "drive_permissions_create", "drive_permissions_update",
       "sheets_values_update", "sheets_values_append",
       "calendar_events_insert", "calendar_events_update",
       "docs_create",
@@ -572,15 +639,15 @@ describe("tool annotation classifications", () => {
     }
   });
 
-  it("classification counts match the intended split (21 read / 8 destructive / 16 additive)", () => {
+  it("classification counts match the intended split (21 read / 9 destructive / 17 additive)", () => {
     const read = allTools.filter((t) => buildAnnotations(t).readOnlyHint === true).length;
     const destructive = allTools.filter((t) => buildAnnotations(t).destructiveHint === true).length;
     const additive = allTools.filter(
       (t) => buildAnnotations(t).readOnlyHint === false && buildAnnotations(t).destructiveHint === false,
     ).length;
     expect(read).toBe(21);
-    expect(destructive).toBe(8);
-    expect(additive).toBe(16);
+    expect(destructive).toBe(9);
+    expect(additive).toBe(17);
     expect(read + destructive + additive).toBe(allTools.length);
   });
 });

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -557,6 +557,7 @@ describe("tool annotation classifications", () => {
       "slides_batchUpdate",
       "sheets_batchUpdate",
       "drive_permissions_delete",
+      "drive_permissions_update",
       "tasks_tasklists_delete",
       "tasks_tasks_delete",
       "tasks_tasks_clear",
@@ -587,7 +588,7 @@ describe("tool annotation classifications", () => {
 
   it("additive writes are readOnlyHint:false with an explicit destructiveHint:false", () => {
     const expectAdditive = [
-      "drive_files_create", "drive_files_copy", "drive_files_update", "drive_permissions_create", "drive_permissions_update",
+      "drive_files_create", "drive_files_copy", "drive_files_update", "drive_permissions_create",
       "sheets_values_update", "sheets_values_append",
       "calendar_events_insert", "calendar_events_update",
       "docs_create",
@@ -639,15 +640,15 @@ describe("tool annotation classifications", () => {
     }
   });
 
-  it("classification counts match the intended split (21 read / 9 destructive / 17 additive)", () => {
+  it("classification counts match the intended split (21 read / 10 destructive / 16 additive)", () => {
     const read = allTools.filter((t) => buildAnnotations(t).readOnlyHint === true).length;
     const destructive = allTools.filter((t) => buildAnnotations(t).destructiveHint === true).length;
     const additive = allTools.filter(
       (t) => buildAnnotations(t).readOnlyHint === false && buildAnnotations(t).destructiveHint === false,
     ).length;
     expect(read).toBe(21);
-    expect(destructive).toBe(9);
-    expect(additive).toBe(17);
+    expect(destructive).toBe(10);
+    expect(additive).toBe(16);
     expect(read + destructive + additive).toBe(allTools.length);
   });
 });

--- a/src/services.ts
+++ b/src/services.ts
@@ -234,7 +234,7 @@ const driveTools: ToolDef[] = [
   },
   {
     name: "drive_permissions_update",
-    description: "Change an existing permission's role on a file (e.g. reader to writer). Per the Drive API: concurrent permissions operations on the same file aren't supported, only the last update is applied.",
+    description: "Change an existing permission's role on a file (e.g. reader to writer). Can remove capabilities by downgrading a role. Ownership transfers are not supported. Per the Drive API: concurrent permissions operations on the same file aren't supported, only the last update is applied.",
     command: ["drive", "permissions", "update"],
     params: [
       { name: "fileId", description: "The file the permission belongs to", type: "string", required: true },
@@ -242,11 +242,11 @@ const driveTools: ToolDef[] = [
       { name: "fields", description: "Fields to return (e.g. \"id,role,type,emailAddress\")", type: "string", required: false },
     ],
     bodyParams: [
-      { name: "role", description: "New role: owner, organizer, fileOrganizer, writer, commenter, reader", type: "string", required: true },
+      { name: "role", description: "New non-owner role", type: "string", required: true, enum: ["organizer", "fileOrganizer", "writer", "commenter", "reader"] },
     ],
     defaultParams: DRIVE_SHARED_DEFAULTS_NO_INCLUDE,
-    // Additive/reversible write, matching drive_files_update: a role change
-    // can be changed back, unlike a delete.
+    // Downgrading a role removes capabilities, so updates are not only additive.
+    destructive: true,
     idempotent: true,
   },
   {

--- a/src/services.ts
+++ b/src/services.ts
@@ -232,6 +232,35 @@ const driveTools: ToolDef[] = [
     defaultParams: DRIVE_SHARED_DEFAULTS_NO_INCLUDE,
     readOnly: true,
   },
+  {
+    name: "drive_permissions_update",
+    description: "Change an existing permission's role on a file (e.g. reader to writer). Per the Drive API: concurrent permissions operations on the same file aren't supported, only the last update is applied.",
+    command: ["drive", "permissions", "update"],
+    params: [
+      { name: "fileId", description: "The file the permission belongs to", type: "string", required: true },
+      { name: "permissionId", description: "The permission to update (get it from drive_permissions_list)", type: "string", required: true },
+      { name: "fields", description: "Fields to return (e.g. \"id,role,type,emailAddress\")", type: "string", required: false },
+    ],
+    bodyParams: [
+      { name: "role", description: "New role: owner, organizer, fileOrganizer, writer, commenter, reader", type: "string", required: true },
+    ],
+    defaultParams: DRIVE_SHARED_DEFAULTS_NO_INCLUDE,
+    // Additive/reversible write, matching drive_files_update: a role change
+    // can be changed back, unlike a delete.
+    idempotent: true,
+  },
+  {
+    name: "drive_permissions_delete",
+    description: "Revoke a permission from a file, removing that user's/group's/domain's access. Per the Drive API: concurrent permissions operations on the same file aren't supported, only the last update is applied.",
+    command: ["drive", "permissions", "delete"],
+    params: [
+      { name: "fileId", description: "The file the permission belongs to", type: "string", required: true },
+      { name: "permissionId", description: "The permission to revoke (get it from drive_permissions_list)", type: "string", required: true },
+    ],
+    defaultParams: DRIVE_SHARED_DEFAULTS_NO_INCLUDE,
+    destructive: true,
+    idempotent: true,
+  },
 ];
 
 // ── Sheets ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds `drive_permissions_update` and `drive_permissions_delete` to the curated MCP registry so agents can change or revoke an existing Drive permission. Both commands inject `supportsAllDrives`; update also accepts a response `fields` mask.

Update supports `organizer`, `fileOrganizer`, `writer`, `commenter`, and `reader`. Ownership transfers are explicitly unsupported: `owner` and invalid roles are rejected by the MCP schema before execution. Both tools advertise `destructiveHint: true` because they can remove capabilities or access, and retain `idempotentHint: true`. They remain excluded in read-only mode.

The registry now exposes 49 tools, including 12 Drive tools. README and server metadata counts are updated. Descriptions preserve Google's warning about concurrent permission operations on the same file.

Validation at `41b0fb5291e63400deec6c91dd6b9709d4818caa`:

- Lint, TypeScript build, and all 184 tests pass.
- Existing argument tests verify shared-drive defaults, field-mask forwarding, and delete's absence of a request body.
- Schema regression test rejects owner, invalid, empty, and omitted roles while accepting all five supported roles.
- MCP client/server annotation test verifies the update tool is advertised as destructive.
- Mutation verification: reintroducing owner fails the schema regression; removing the destructive flag fails the MCP annotation test. Restored final tree passes.
- Hosted CI: all five checks pass, including Linux/Windows on Node 20/22. Independent final review by authenticated `claude-opus-5`, `opencode/muse-spark-1.3-contributor-free`, and `opencode/nemotron-3-ultra-free` found no blocking defects at the exact final SHA. Each reviewed the repair delta; unchanged original PR coverage carries forward from `68f445bdd3ed34899f679ff02806fb285a0cb53c`. Public-only inspected packets and enforced tool-free review; no setup failures or unresolved verified findings.

Review fixes deliberately keep ownership transfer outside this tool's scope; no transfer acknowledgment is silently defaulted.
