### PR TITLE
Add Drive comments and replies (10 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gws-mcp-server
 
-Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks as a curated set of 51 [Model Context Protocol](https://modelcontextprotocol.io/) tools, built on the official [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli).
+Google Workspace for AI agents: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks as a curated set of 61 [Model Context Protocol](https://modelcontextprotocol.io/) tools, built on the official [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli).
 
 [![npm version](https://img.shields.io/npm/v/gws-mcp-server?style=flat-square)](https://www.npmjs.com/package/gws-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
@@ -102,7 +102,7 @@ npm install && npm run build
 
 ### `--read-only`
 
-`--read-only` registers **22 tools** instead of 51. Every tool that writes to Google is left unregistered, so it never appears in `tools/list` and there is nothing for an agent to call — including `gmail_drafts_create`, which is a write even though it never sends. `drive_files_download` stays, since it reads.
+`--read-only` registers **26 tools** instead of 61. Every tool that writes to Google is left unregistered, so it never appears in `tools/list` and there is nothing for an agent to call — including `gmail_drafts_create`, which is a write even though it never sends. `drive_files_download` stays, since it reads.
 
 ```bash
 gws-mcp-server --read-only
@@ -113,7 +113,7 @@ This constrains the **agent, not the credential**. The token on disk keeps whate
 
 ### Trimming context cost
 
-Every registered tool rides along in each conversation: the full registry is roughly 37 KB of `tools/list` payload (~9.5K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
+Every registered tool rides along in each conversation: the full registry is roughly 46 KB of `tools/list` payload (~11.8K tokens) that your MCP client loads before anything else happens. The two flags above compose, and dropping whole services you don't use is the cheapest context win there is:
 
 ```bash
 gws-mcp-server --services calendar                       # calendar assistant: 6 tools
@@ -127,11 +127,11 @@ In `.mcp.json` or `claude_desktop_config.json`, the same trimming is just editin
 "args": ["gws-mcp-server", "--services", "drive,calendar"]
 ```
 
-A service's tool count (headers below) tracks its context cost: dropping `tasks` (12 tools) saves the most, `docs` (3 tools) the least. There is no per-tool exclude flag today — if service granularity is too coarse for your setup, [open an issue](https://github.com/conorbronsdon/gws-mcp-server/issues) describing the split you need.
+A service's tool count (headers below) tracks its context cost: dropping `drive` (24 tools) saves the most, `docs` (3 tools) the least. There is no per-tool exclude flag today — if service granularity is too coarse for your setup, [open an issue](https://github.com/conorbronsdon/gws-mcp-server/issues) describing the split you need.
 
 ## Available services & tools
 
-### `drive` (14 tools)
+### `drive` (24 tools)
 - `drive_files_list` — Search and list files
 - `drive_files_get` — Get file metadata
 - `drive_files_create` — Create files (with optional upload)
@@ -146,6 +146,16 @@ A service's tool count (headers below) tracks its context cost: dropping `tasks`
 - `drive_permissions_delete` — Revoke a permission from a file
 - `drive_permissions_transferOwnership` — Immediately transfer ownership to another Google Workspace account in the SAME organization, downgrading the current owner to writer; sends a mandatory notification email; not supported for shared drive files
 - `drive_permissions_proposeOwnershipTransfer` — Propose transferring ownership between personal/consumer accounts; the recipient must separately accept (mandatory email notification), this doesn't transfer it outright
+- `drive_comments_list` — List comments on a file (works on any Drive file, not just Docs/Sheets/Slides)
+- `drive_comments_get` — Get a single comment
+- `drive_comments_create` — Add a comment, optionally anchored to an app-defined region (Workspace editors still show it as unanchored)
+- `drive_comments_update` — Change a comment's text (author-only)
+- `drive_comments_delete` — Permanently delete a comment (author-only)
+- `drive_replies_list` — List replies to a comment
+- `drive_replies_get` — Get a single reply
+- `drive_replies_create` — Reply to a comment, or resolve/reopen it via the `action` field
+- `drive_replies_update` — Change a reply's text (author-only)
+- `drive_replies_delete` — Permanently delete a reply (author-only)
 
 ### `sheets` (5 tools)
 - `sheets_get` — Get spreadsheet metadata
@@ -198,7 +208,7 @@ A service's tool count (headers below) tracks its context cost: dropping `tasks`
 
 > **Update semantics:** the `*_update` tools (calendar events, tasks, task lists) use the Google API's `patch` verb — they merge the fields you supply and leave the rest untouched. To *clear* an existing value, pass it explicitly (e.g. an empty string) rather than omitting it.
 
-**Total: 51 tools** (vs 200-400 in the old implementation)
+**Total: 61 tools** (vs 200-400 in the old implementation)
 
 ## Adding new tools
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.conorbronsdon/gws-mcp-server",
   "title": "Google Workspace MCP Server",
-  "description": "Google Workspace as 51 curated MCP tools: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks.",
+  "description": "Google Workspace as 61 curated MCP tools: Gmail, Calendar, Drive, Sheets, Docs, Slides, and Tasks.",
   "repository": {
     "url": "https://github.com/conorbronsdon/gws-mcp-server",
     "source": "github"

--- a/src/__tests__/annotations.e2e.test.ts
+++ b/src/__tests__/annotations.e2e.test.ts
@@ -58,7 +58,7 @@ const byName = (n: string): ListedTool => {
 
 describe("advertised annotations", () => {
   it("registers all four hand-written tools alongside the registry tools", () => {
-    expect(tools.length).toBe(51);
+    expect(tools.length).toBe(61);
     expect(byName("drive_files_download")).toBeDefined();
     expect(byName("gmail_drafts_create")).toBeDefined();
     expect(byName("drive_permissions_transferOwnership")).toBeDefined();
@@ -117,10 +117,14 @@ describe("advertised annotations", () => {
     expect(destructive).toEqual([
       "calendar_events_delete",
       "docs_batchUpdate",
+      "drive_comments_delete",
+      "drive_comments_update",
       "drive_files_delete",
       "drive_permissions_delete",
       "drive_permissions_transferOwnership",
       "drive_permissions_update",
+      "drive_replies_delete",
+      "drive_replies_update",
       "sheets_batchUpdate",
       "slides_batchUpdate",
       "tasks_tasklists_delete",
@@ -157,8 +161,8 @@ describe("startup tool count", () => {
     // Guards against the fix being "fudge the string": the number has to come
     // from somewhere other than the registry length.
     const registry = getToolsForServices(ALL_SERVICES);
-    expect(registry.length).toBe(47);
-    expect(countRegisteredTools(registry, ALL_SERVICES)).toBe(51);
+    expect(registry.length).toBe(57);
+    expect(countRegisteredTools(registry, ALL_SERVICES)).toBe(61);
     expect(countRegisteredTools(registry, ["sheets"])).toBe(registry.length);
   });
 });
@@ -176,9 +180,9 @@ describe("--read-only", () => {
     roTools = (await client.listTools()).tools as ListedTool[];
   });
 
-  it("exposes exactly the 22 read-only tools", () => {
-    expect(roTools.length).toBe(22);
-    expect(countRegisteredTools(getToolsForServices(ALL_SERVICES), ALL_SERVICES, true)).toBe(22);
+  it("exposes exactly the 26 read-only tools", () => {
+    expect(roTools.length).toBe(26);
+    expect(countRegisteredTools(getToolsForServices(ALL_SERVICES), ALL_SERVICES, true)).toBe(26);
   });
 
   it("lists no tool that advertises itself as a write", () => {
@@ -190,8 +194,8 @@ describe("--read-only", () => {
     const dropped = tools
       .filter((t) => t.annotations?.readOnlyHint !== true)
       .map((t) => t.name);
-    // 51 default - 22 read-only = 29 writes, all gone.
-    expect(dropped.length).toBe(29);
+    // 61 default - 26 read-only = 35 writes, all gone.
+    expect(dropped.length).toBe(35);
     for (const name of dropped) {
       expect(roTools.find((t) => t.name === name)).toBeUndefined();
     }
@@ -208,7 +212,7 @@ describe("--read-only", () => {
   });
 
   it("is additive — the default server is unchanged", () => {
-    expect(tools.length).toBe(51);
+    expect(tools.length).toBe(61);
     expect(tools.find((t) => t.name === "gmail_drafts_create")).toBeDefined();
     expect(tools.find((t) => t.name === "drive_files_delete")).toBeDefined();
   });
@@ -233,8 +237,8 @@ describe("idempotentHint / openWorldHint", () => {
       .filter((t) => typeof t.annotations?.openWorldHint !== "boolean")
       .map((t) => t.name);
     expect(missing).toEqual([]);
-    // All 51 reach Google Workspace, whose state changes independently of us.
-    expect(tools.filter((t) => t.annotations?.openWorldHint === true).length).toBe(51);
+    // All 61 reach Google Workspace, whose state changes independently of us.
+    expect(tools.filter((t) => t.annotations?.openWorldHint === true).length).toBe(61);
   });
 
   it("every write advertises idempotentHint, and no read does", () => {
@@ -263,10 +267,14 @@ describe("idempotentHint / openWorldHint", () => {
       .sort();
     expect(idempotent).toEqual([
       "calendar_events_delete",
+      "drive_comments_delete",
+      "drive_comments_update",
       "drive_files_delete",
       "drive_files_update",
       "drive_permissions_delete",
       "drive_permissions_update",
+      "drive_replies_delete",
+      "drive_replies_update",
       "gmail_threads_modify",
       "sheets_values_update",
       "tasks_tasklists_delete",
@@ -293,11 +301,13 @@ describe("idempotentHint / openWorldHint", () => {
       "calendar_events_update",
       "docs_batchUpdate",
       "docs_create",
+      "drive_comments_create",
       "drive_files_copy",
       "drive_files_create",
       "drive_permissions_create",
       "drive_permissions_proposeOwnershipTransfer",
       "drive_permissions_transferOwnership",
+      "drive_replies_create",
       "gmail_drafts_create",
       "sheets_batchUpdate",
       "sheets_values_append",
@@ -340,13 +350,13 @@ describe("idempotentHint / openWorldHint", () => {
     });
   });
 
-  it("accounts for all 51 tools", () => {
+  it("accounts for all 61 tools", () => {
     const reads = tools.filter((t) => t.annotations?.readOnlyHint === true).length;
     const idem = tools.filter((t) => t.annotations?.idempotentHint === true).length;
     const nonIdem = tools.filter((t) => t.annotations?.idempotentHint === false).length;
-    expect(reads).toBe(22);
-    expect(idem + nonIdem).toBe(51 - reads);
-    expect(idem).toBe(13);
-    expect(nonIdem).toBe(16);
+    expect(reads).toBe(26);
+    expect(idem + nonIdem).toBe(61 - reads);
+    expect(idem).toBe(17);
+    expect(nonIdem).toBe(18);
   });
 });

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { z } from "zod";
 import { getToolsForServices, SERVICE_TOOLS, ALL_SERVICES, buildAnnotations, type ToolDef } from "../services.js";
 import { buildArgs, escapeJsonArg } from "../executor.js";
 import { buildZodSchema } from "../index.js";
@@ -59,7 +60,7 @@ describe("tool definitions integrity", () => {
   });
 
   it("has correct tool counts per service", () => {
-    expect(SERVICE_TOOLS["drive"].length).toBe(11);
+    expect(SERVICE_TOOLS["drive"].length).toBe(21);
     expect(SERVICE_TOOLS["sheets"].length).toBe(5);
     expect(SERVICE_TOOLS["calendar"].length).toBe(6);
     expect(SERVICE_TOOLS["docs"].length).toBe(3);
@@ -68,8 +69,8 @@ describe("tool definitions integrity", () => {
     expect(SERVICE_TOOLS["tasks"].length).toBe(12);
   });
 
-  it("total tool count is 47", () => {
-    expect(allTools.length).toBe(47);
+  it("total tool count is 57", () => {
+    expect(allTools.length).toBe(57);
   });
 
   it("all params have required fields", () => {
@@ -456,6 +457,86 @@ describe("drive_permissions_delete (shared drives)", () => {
   });
 });
 
+// ── Drive comments/replies: fields is mandatory for comments, not replies ──
+// developers.google.com/workspace/drive/api/guides/manage-comments states
+// this explicitly: "For all methods (excluding delete) on the comments
+// resource, you must set the fields system parameter... If you omit the
+// fields parameter, the method returns an error." Confirmed directly against
+// `gws schema drive.comments.*`/`drive.replies.*`: only comments.list/get/
+// create/update carry "Required: The fields parameter must be set" in their
+// description; none of the replies.* methods do. Getting this backwards in
+// either direction is a real, silent functional gap: too strict on replies
+// blocks a valid no-fields call, too loose on comments ships a tool that
+// always 400s unless the caller happens to pass fields anyway.
+
+describe("drive comments tools require fields; drive replies tools don't", () => {
+  const driveByName = new Map(SERVICE_TOOLS["drive"].map((t) => [t.name, t]));
+  const commentsToolsNeedingFields = ["drive_comments_list", "drive_comments_get", "drive_comments_create", "drive_comments_update"];
+  const repliesTools = ["drive_replies_list", "drive_replies_get", "drive_replies_create", "drive_replies_update"];
+
+  it("every comments.* method except delete requires fields", () => {
+    for (const name of commentsToolsNeedingFields) {
+      const tool = driveByName.get(name)!;
+      const fields = tool.params.find((p) => p.name === "fields");
+      expect(fields, `${name} should declare 'fields'`).toBeDefined();
+      expect(fields!.required, `${name}'s fields param should be required`).toBe(true);
+    }
+  });
+
+  it("drive_comments_delete declares no fields param at all — delete has no response body to select fields from", () => {
+    const tool = driveByName.get("drive_comments_delete")!;
+    expect(tool.params.find((p) => p.name === "fields")).toBeUndefined();
+  });
+
+  it("no replies.* method requires fields", () => {
+    for (const name of repliesTools) {
+      const tool = driveByName.get(name)!;
+      const fields = tool.params.find((p) => p.name === "fields");
+      // fields is still offered (useful for trimming the response), just not required.
+      expect(fields, `${name} should declare 'fields'`).toBeDefined();
+      expect(fields!.required, `${name}'s fields param should be optional`).toBe(false);
+    }
+  });
+
+  it("omitting fields on a required-fields comments tool is a schema-level rejection, not a runtime surprise", () => {
+    const tool = driveByName.get("drive_comments_list")!;
+    const schema = z.object(buildZodSchema(tool));
+    expect(schema.safeParse({ fileId: "file123" }).success).toBe(false);
+    expect(schema.safeParse({ fileId: "file123", fields: "comments(id)" }).success).toBe(true);
+  });
+});
+
+describe("drive_replies_create (resolve/reopen)", () => {
+  const tool = SERVICE_TOOLS["drive"].find((t) => t.name === "drive_replies_create")!;
+
+  it("constrains action to resolve/reopen — pins the real tool, not just buildZodSchema's enum branch", () => {
+    const action = tool.bodyParams!.find((p) => p.name === "action")!;
+    expect(action.enum).toEqual(["resolve", "reopen"]);
+
+    const schema = buildZodSchema(tool);
+    expect(schema.action.safeParse("resolve").success).toBe(true);
+    expect(schema.action.safeParse("reopen").success).toBe(true);
+    expect(schema.action.safeParse("close").success).toBe(false);
+    // Optional still holds: a plain text reply with no action is valid.
+    expect(schema.action.safeParse(undefined).success).toBe(true);
+  });
+
+  it("sends action through to the request body, alongside content", () => {
+    const args = buildArgs(tool, { fileId: "file123", commentId: "c1", action: "resolve", content: "done" });
+    const jsonIdx = args.indexOf("--json");
+    expect(args[jsonIdx + 1]).toBe(escapeJsonArg(JSON.stringify({ content: "done", action: "resolve" })));
+  });
+
+  it("is additive, not destructive — resolving/reopening doesn't block replies or hide anything server-side", () => {
+    // Judgment call, stated explicitly so it can be argued with: matches
+    // gmail_threads_modify's TRASH-label reasoning (a reversible state flag),
+    // not a data-loss operation.
+    const a = buildAnnotations(tool);
+    expect(a.readOnlyHint).toBe(false);
+    expect(a.destructiveHint).toBe(false);
+  });
+});
+
 // ── Tool annotations (issue #5) ──────────────────────────────────────────
 
 describe("buildAnnotations mapping", () => {
@@ -558,6 +639,10 @@ describe("tool annotation classifications", () => {
       "sheets_batchUpdate",
       "drive_permissions_delete",
       "drive_permissions_update",
+      "drive_comments_update",
+      "drive_comments_delete",
+      "drive_replies_update",
+      "drive_replies_delete",
       "tasks_tasklists_delete",
       "tasks_tasks_delete",
       "tasks_tasks_clear",
@@ -572,6 +657,7 @@ describe("tool annotation classifications", () => {
   it("named read tools carry readOnlyHint:true", () => {
     const expectReadOnly = [
       "drive_files_list", "drive_files_get", "drive_files_export", "drive_permissions_list",
+      "drive_comments_list", "drive_comments_get", "drive_replies_list", "drive_replies_get",
       "sheets_get", "sheets_values_get",
       "calendar_events_list", "calendar_events_get", "calendar_freebusy_query",
       "docs_get",
@@ -589,6 +675,7 @@ describe("tool annotation classifications", () => {
   it("additive writes are readOnlyHint:false with an explicit destructiveHint:false", () => {
     const expectAdditive = [
       "drive_files_create", "drive_files_copy", "drive_files_update", "drive_permissions_create",
+      "drive_comments_create", "drive_replies_create",
       "sheets_values_update", "sheets_values_append",
       "calendar_events_insert", "calendar_events_update",
       "docs_create",
@@ -640,15 +727,15 @@ describe("tool annotation classifications", () => {
     }
   });
 
-  it("classification counts match the intended split (21 read / 10 destructive / 16 additive)", () => {
+  it("classification counts match the intended split (25 read / 14 destructive / 18 additive)", () => {
     const read = allTools.filter((t) => buildAnnotations(t).readOnlyHint === true).length;
     const destructive = allTools.filter((t) => buildAnnotations(t).destructiveHint === true).length;
     const additive = allTools.filter(
       (t) => buildAnnotations(t).readOnlyHint === false && buildAnnotations(t).destructiveHint === false,
     ).length;
-    expect(read).toBe(21);
-    expect(destructive).toBe(10);
-    expect(additive).toBe(16);
+    expect(read).toBe(25);
+    expect(destructive).toBe(14);
+    expect(additive).toBe(18);
     expect(read + destructive + additive).toBe(allTools.length);
   });
 });

--- a/src/services.ts
+++ b/src/services.ts
@@ -261,6 +261,160 @@ const driveTools: ToolDef[] = [
     destructive: true,
     idempotent: true,
   },
+  // Comments/replies: usable on any Drive file (not just Docs/Sheets/Slides),
+  // since this is the Drive API's comments resource, not the editor APIs'.
+  // Google Workspace editor apps (Docs/Sheets/Slides) treat comments created
+  // here as unanchored regardless of the anchor field — use the Docs/Sheets/
+  // Slides APIs directly for comments that need to visually bind to content
+  // in those editors. Neither comments nor replies support supportsAllDrives
+  // — confirmed absent from every comments.*/replies.* method's parameters,
+  // unlike every other Drive resource here.
+  {
+    name: "drive_comments_list",
+    description: "List comments on a file.",
+    command: ["drive", "comments", "list"],
+    params: [
+      { name: "fileId", description: "The file to list comments for", type: "string", required: true },
+      { name: "includeDeleted", description: "Whether to include deleted comments (they have no content)", type: "boolean", required: false },
+      { name: "pageSize", description: "Max comments to return (default 20)", type: "number", required: false },
+      { name: "pageToken", description: "Page token from a previous call", type: "string", required: false },
+      { name: "startModifiedTime", description: "Only return comments modified at or after this time (RFC 3339)", type: "string", required: false },
+      // The comments resource requires fields on every method except delete —
+      // omitting it is a hard API error here, unlike most Drive resources
+      // where fields only trims the response.
+      { name: "fields", description: "Fields to include (required by the API for this resource, e.g. \"comments(id,content,author,resolved),nextPageToken\")", type: "string", required: true },
+    ],
+    readOnly: true,
+  },
+  {
+    name: "drive_comments_get",
+    description: "Get a single comment on a file.",
+    command: ["drive", "comments", "get"],
+    params: [
+      { name: "fileId", description: "The file the comment belongs to", type: "string", required: true },
+      { name: "commentId", description: "The comment to retrieve", type: "string", required: true },
+      { name: "includeDeleted", description: "Whether to return the comment if it has been deleted (it will have no content)", type: "boolean", required: false },
+      { name: "fields", description: "Fields to include (required by the API for this resource, e.g. \"id,content,author,resolved,replies\")", type: "string", required: true },
+    ],
+    readOnly: true,
+  },
+  {
+    name: "drive_comments_create",
+    description: "Add a comment to a file. Set anchor to bind it to an app-defined region — Drive stores this as an opaque JSON string you define yourself, and does not validate or interpret it. Google Workspace editor apps (Docs/Sheets/Slides) still display comments created this way as unanchored; use the Docs/Sheets/Slides APIs directly if visual anchoring in those editors matters.",
+    command: ["drive", "comments", "create"],
+    params: [
+      { name: "fileId", description: "The file to comment on", type: "string", required: true },
+      { name: "fields", description: "Fields to include in the response (required by the API for this resource, e.g. \"id,content,createdTime\")", type: "string", required: true },
+    ],
+    bodyParams: [
+      { name: "content", description: "Comment text", type: "string", required: true },
+      { name: "anchor", description: "App-defined region JSON string, optional (e.g. '{\"line\":10}')", type: "string", required: false },
+    ],
+  },
+  {
+    name: "drive_comments_update",
+    description: "Change the text of an existing comment. This overwrites the comment's content; the previous text is not retained. Only the comment's own author can update it — the API rejects the request otherwise. The resolved state can't be changed here: see drive_replies_create's action field.",
+    command: ["drive", "comments", "update"],
+    params: [
+      { name: "fileId", description: "The file the comment belongs to", type: "string", required: true },
+      { name: "commentId", description: "The comment to update", type: "string", required: true },
+      { name: "fields", description: "Fields to include in the response (required by the API for this resource, e.g. \"id,content,modifiedTime\")", type: "string", required: true },
+    ],
+    bodyParams: [
+      { name: "content", description: "New comment text", type: "string", required: true },
+    ],
+    // Matches drive_permissions_update/drive_files_update: repeating the
+    // same content leaves the comment in the same end state.
+    destructive: true,
+    idempotent: true,
+  },
+  {
+    name: "drive_comments_delete",
+    description: "Permanently delete a comment. Only the comment's own author can delete it — the API rejects the request otherwise.",
+    command: ["drive", "comments", "delete"],
+    params: [
+      { name: "fileId", description: "The file the comment belongs to", type: "string", required: true },
+      { name: "commentId", description: "The comment to delete", type: "string", required: true },
+    ],
+    destructive: true,
+    idempotent: true,
+  },
+  {
+    name: "drive_replies_list",
+    description: "List replies to a comment.",
+    command: ["drive", "replies", "list"],
+    params: [
+      { name: "fileId", description: "The file the comment belongs to", type: "string", required: true },
+      { name: "commentId", description: "The comment to list replies for", type: "string", required: true },
+      { name: "includeDeleted", description: "Whether to include deleted replies (they have no content)", type: "boolean", required: false },
+      { name: "pageSize", description: "Max replies to return (default 20)", type: "number", required: false },
+      { name: "pageToken", description: "Page token from a previous call", type: "string", required: false },
+      { name: "fields", description: "Fields to include (e.g. \"replies(id,content,action),nextPageToken\")", type: "string", required: false },
+    ],
+    readOnly: true,
+  },
+  {
+    name: "drive_replies_get",
+    description: "Get a single reply to a comment.",
+    command: ["drive", "replies", "get"],
+    params: [
+      { name: "fileId", description: "The file the comment belongs to", type: "string", required: true },
+      { name: "commentId", description: "The parent comment", type: "string", required: true },
+      { name: "replyId", description: "The reply to retrieve", type: "string", required: true },
+      { name: "includeDeleted", description: "Whether to return the reply if it has been deleted (it will have no content)", type: "boolean", required: false },
+      { name: "fields", description: "Fields to include (e.g. \"id,content,action\")", type: "string", required: false },
+    ],
+    readOnly: true,
+  },
+  {
+    name: "drive_replies_create",
+    description: "Add a reply to a comment, or resolve/reopen it — a comment can only be resolved or reopened by posting a reply with action set. content is required unless action is set; combine both to leave closing/reopening text. Setting action changes the parent comment's resolved field, but resolving is advisory only: the API keeps accepting further replies and doesn't hide anything itself, it's on the client to act on resolved being true (e.g. hide or dim the thread).",
+    command: ["drive", "replies", "create"],
+    params: [
+      { name: "fileId", description: "The file the comment belongs to", type: "string", required: true },
+      { name: "commentId", description: "The comment to reply to", type: "string", required: true },
+      { name: "fields", description: "Fields to include (e.g. \"id,content,action\")", type: "string", required: false },
+    ],
+    bodyParams: [
+      { name: "content", description: "Reply text. Required if action is not set", type: "string", required: false },
+      { name: "action", description: "Set to change the parent comment's resolved state instead of (or alongside) replying with text", type: "string", required: false, enum: ["resolve", "reopen"] },
+    ],
+    // Additive: resolving/reopening is a reversible state toggle the API
+    // itself doesn't enforce anything on (no replies are blocked, nothing is
+    // hidden server-side) — matches gmail_threads_modify's TRASH-label
+    // reasoning, not a data-loss operation. Judgment call: open to
+    // reclassifying if that read is wrong.
+  },
+  {
+    name: "drive_replies_update",
+    description: "Change the text of an existing reply. This overwrites the reply's content; the previous text is not retained. Only the reply's own author can update it — the API rejects the request otherwise. Does not support changing action — use drive_replies_create to resolve/reopen.",
+    command: ["drive", "replies", "update"],
+    params: [
+      { name: "fileId", description: "The file the comment belongs to", type: "string", required: true },
+      { name: "commentId", description: "The parent comment", type: "string", required: true },
+      { name: "replyId", description: "The reply to update", type: "string", required: true },
+      { name: "fields", description: "Fields to include (e.g. \"id,content,modifiedTime\")", type: "string", required: false },
+    ],
+    bodyParams: [
+      { name: "content", description: "New reply text", type: "string", required: true },
+    ],
+    // Matches drive_permissions_update/drive_files_update: repeating the
+    // same content leaves the reply in the same end state.
+    destructive: true,
+    idempotent: true,
+  },
+  {
+    name: "drive_replies_delete",
+    description: "Permanently delete a reply. Only the reply's own author can delete it — the API rejects the request otherwise.",
+    command: ["drive", "replies", "delete"],
+    params: [
+      { name: "fileId", description: "The file the comment belongs to", type: "string", required: true },
+      { name: "commentId", description: "The parent comment", type: "string", required: true },
+      { name: "replyId", description: "The reply to delete", type: "string", required: true },
+    ],
+    destructive: true,
+    idempotent: true,
+  },
 ];
 
 // ── Sheets ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`gws` already fully implements the Drive comments/replies resources, but none of the 10 methods were wired into the MCP tool registry. Read the full [manage-comments guide](https://developers.google.com/workspace/drive/api/guides/manage-comments) this time, not just the schema — the lesson from #60 was that a truncated doc read misses a whole flow, and this guide had real, load-bearing details the schema alone doesn't surface.

**Two corrections to my original plan, both schema-verified before writing anything:**

- `comments.delete` and `replies.delete` both exist. My original plan assumed neither did — wrong, confirmed via `gws schema drive.comments.delete`/`drive.replies.delete`, both real `DELETE` methods. Added `drive_comments_delete` and `drive_replies_delete`.
- `fields` is mandatory for every `comments.*` method except delete — the guide states this explicitly ("If you omit the fields parameter, the method returns an error"), and `gws schema` confirms it via "Required: The `fields` parameter must be set" on `list`/`get`/`create`/`update`'s descriptions. None of the `replies.*` methods carry that same requirement. Declared `fields` as `required: true` on the four comments methods that need it, `required: false` everywhere else — getting this backwards in either direction is a real bug (too strict on replies blocks a valid call, too loose on comments ships a tool that always errors).

10 tools total: `drive_comments_{list,get,create,update,delete}`, `drive_replies_{list,get,create,update,delete}`. Neither resource supports `supportsAllDrives` — confirmed absent from every one of the 10 schemas, unlike every other Drive resource here, so no `defaultParams` gap to worry about this time.

`drive_replies_create`'s `action` field (`resolve`/`reopen`) is enum-locked the same way #58/#60 established. Classified additive, not destructive — a judgment call stated explicitly in a code comment and a dedicated test: resolving/reopening is a reversible state toggle the API doesn't enforce anything around, matching `gmail_threads_modify`'s TRASH-label reasoning rather than a data-loss operation.

`comments_update`/`replies_update` are idempotent (repeating the same content leaves the same end state) — the real analogy this time is `drive_permissions_update`/`drive_files_update`, applied deliberately rather than caught in review like last time.

Also fixed a now-stale comparative claim in the README ("dropping `tasks` saves the most") — this PR's own tool-count changes made it false, since `drive` is now 24 tools vs `tasks`' 12.

Regression tests are proactive: a dedicated block pins the `fields` required/optional asymmetry across all 8 non-delete methods, plus a schema-level `safeParse` check that omitting `fields` on a comments tool is actually rejected. Mutation-verified before opening: flipping `drive_comments_list`'s `fields` to optional fails 2 tests; removing the `action` enum fails 1 test.

**Verified live end-to-end**, not schema-only — unlike the ownership-transfer tools, nothing here has a third-party side effect, so it was safe to fully exercise: created a disposable file, added a comment, replied to it, resolved it (confirmed `resolved: true`), reopened it (confirmed `resolved: false`), updated both the comment and reply text, deleted the reply and the comment (confirmed both tombstoned via `includeDeleted`), then deleted the test file and confirmed it's gone.

## Checklist

- [x] `npm run lint` and `npm test` pass (194/194, tests mock the executor, no real `gws` calls)
- [x] New tools are narrowly scoped and map to a single `gws` CLI command each (keeps the curated contract)
- [x] No shell-injection surface: args go through `src/executor.ts`, never string-concatenated commands
- [x] README service/tool list and total count updated (51 → 61, drive 14 → 24), including the measured `tools/list` payload size (47,173 B, ~46 KB / ~11.8K tokens)